### PR TITLE
chore: AuthorityController의 이름을 naming convention에 맞게 수정 (#37)

### DIFF
--- a/src/main/java/com/newfit/reservation/controller/AuthorityApiController.java
+++ b/src/main/java/com/newfit/reservation/controller/AuthorityApiController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/authority")
 @RequiredArgsConstructor
-public class AuthorityController {
+public class AuthorityApiController {
     private final AuthorityService authorityService;
 
     @PostMapping


### PR DESCRIPTION
## 개요
- close #37 
## 작업사항
- AuthorityController의 이름을 AuthorityApiController로 변경