### PR TITLE
fix: getHeader의 name을 authorityId로 수정 (#62)

### DIFF
--- a/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
@@ -78,7 +78,7 @@ public class TokenProvider {
 
     public Authentication getAuthentication(String token, HttpServletRequest request) {
         Claims claims = getClaims(token);
-        Authority authority = authorityRepository.findOne(Long.parseLong(request.getHeader("authority")))
+        Authority authority = authorityRepository.findOne(Long.parseLong(request.getHeader("authorityId")))
                 .orElseThrow(IllegalArgumentException::new);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(authority.getRole().getDescription()));
 


### PR DESCRIPTION
## 개요
- close #62 
## 작업사항
- getHeader의 header name을 수정