### PR TITLE
refactor: Authority가 없는 회원의 인가 처리 (#65)

### DIFF
--- a/src/main/java/com/newfit/reservation/common/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/newfit/reservation/common/config/TokenAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -22,8 +23,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = getAccessToken(request);
 
-        if(tokenProvider.validToken(accessToken, request)) {
+        if(requiresValidityCheck(request) && tokenProvider.validToken(accessToken, request)) {
             Authentication authentication = tokenProvider.getAuthentication(accessToken, request);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            Authentication authentication = tokenProvider.getAnonymousAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         filterChain.doFilter(request, response);
@@ -35,5 +39,12 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             return authorizationHeader.substring(BEARER.length());
         }
         return null;
+    }
+
+    private boolean requiresValidityCheck(HttpServletRequest request) {
+        if (request.getRequestURI().equals("/api/v1/authority") && request.getMethod().equals(HttpMethod.POST.toString())) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/newfit/reservation/common/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/newfit/reservation/common/config/TokenAuthenticationFilter.java
@@ -22,7 +22,10 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = getAccessToken(request);
-
+        if(request.getRequestURI().equals("/login") || accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         if(requiresValidityCheck(request) && tokenProvider.validToken(accessToken, request)) {
             Authentication authentication = tokenProvider.getAuthentication(accessToken, request);
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -43,6 +46,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean requiresValidityCheck(HttpServletRequest request) {
         if (request.getRequestURI().equals("/api/v1/authority") && request.getMethod().equals(HttpMethod.POST.toString())) {
+            return false;
+        }
+        if (request.getRequestURI().equals("/api/v1/gyms") && request.getMethod().equals(HttpMethod.GET.toString())) {
             return false;
         }
         return true;

--- a/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
@@ -67,8 +67,8 @@ public class TokenProvider {
     }
 
     private void checkAuthorityIdList(String token, HttpServletRequest request) {
-        List<Long> authorityIdList = getAuthorityIdList(token);
-        Long authorityId = authorityRepository.findOne(Long.parseLong(request.getHeader("authorityId"))).orElseThrow(IllegalArgumentException::new).getId();
+        List<Integer> authorityIdList = getAuthorityIdList(token);
+        Integer authorityId = authorityRepository.findOne(Long.parseLong(request.getHeader("authorityId"))).orElseThrow(IllegalArgumentException::new).getId().intValue();
         authorityIdList
                 .stream()
                 .filter(authority -> authority.equals(authorityId))

--- a/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
@@ -1,6 +1,7 @@
 package com.newfit.reservation.common.jwt;
 
 import com.newfit.reservation.domain.Authority;
+import com.newfit.reservation.domain.Role;
 import com.newfit.reservation.domain.User;
 import com.newfit.reservation.repository.AuthorityRepository;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/jwt/TokenProvider.java
@@ -85,7 +85,15 @@ public class TokenProvider {
         return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
     }
 
-    public List<Long> getAuthorityIdList(String token) {
+    // 등록된 Gym이 없는 회원의 Authentication을 반환
+    public Authentication getAnonymousAuthentication(String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(Role.GUEST.getDescription()));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    public List<Integer> getAuthorityIdList(String token) {
         Claims claims = getClaims(token);
         return claims.get("authorityIdList", List.class);
     }

--- a/src/main/java/com/newfit/reservation/domain/Role.java
+++ b/src/main/java/com/newfit/reservation/domain/Role.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Role {
-    USER("user"), MANAGER("manager");
+    USER("user"), MANAGER("manager"), GUEST("guest");
 
     private final String description;
 }


### PR DESCRIPTION
## 개요
- close #65 
## 작업사항
- "/api/v1/authority"의 Post 요청을 위한 인가 처리
- Authority가 존재하지 않는 회원에 대한 TokenAuthenticationFilter 로직 추가
- Role에 Guest 추가