### PR TITLE
refactor: Controller 내부 권한 체크 로직 보완 (#176)

### DIFF
--- a/src/main/java/com/newfit/reservation/common/RequestHeaderUtil.java
+++ b/src/main/java/com/newfit/reservation/common/RequestHeaderUtil.java
@@ -1,0 +1,23 @@
+package com.newfit.reservation.common;
+
+import com.newfit.reservation.service.AuthorityService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RequestHeaderUtil {
+
+    private final AuthorityService authorityService;
+
+    public Long extractUserId(HttpServletRequest request) {
+        if (request.getHeader("user-id") != null) {
+            return Long.parseLong(request.getHeader("user-id"));
+        } else {
+            Long authorityId = Long.parseLong(request.getHeader("authority-id"));
+            // TODO: user 잘 fetch 하는지 체크할 것
+            return authorityService.findById(authorityId).getUser().getId();
+        }
+    }
+}

--- a/src/main/java/com/newfit/reservation/common/RequestHeaderUtil.java
+++ b/src/main/java/com/newfit/reservation/common/RequestHeaderUtil.java
@@ -16,7 +16,6 @@ public class RequestHeaderUtil {
             return Long.parseLong(request.getHeader("user-id"));
         } else {
             Long authorityId = Long.parseLong(request.getHeader("authority-id"));
-            // TODO: user 잘 fetch 하는지 체크할 것
             return authorityService.findById(authorityId).getUser().getId();
         }
     }

--- a/src/main/java/com/newfit/reservation/common/auth/AuthorityCheckService.java
+++ b/src/main/java/com/newfit/reservation/common/auth/AuthorityCheckService.java
@@ -4,6 +4,7 @@ import com.newfit.reservation.domain.Authority;
 import com.newfit.reservation.exception.CustomException;
 import com.newfit.reservation.repository.AuthorityRepository;
 import com.newfit.reservation.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
@@ -18,13 +19,12 @@ public class AuthorityCheckService {
     private final UserRepository userRepository;
     private final AuthorityRepository authorityRepository;
 
-    public void validateByUserId(Authentication authentication, Long userId) {
-        User principal = (User) authentication.getPrincipal();
-        com.newfit.reservation.domain.User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
-        String nickname = principal.getUsername();
-        if (!user.getNickname().equals(nickname)) {
+    public void checkHeaderAndValidateAuthority(Authentication authentication, HttpServletRequest request) {
+        if (request.getHeader("user-id") != null) {
+            validateByUserId(authentication, Long.parseLong(request.getHeader("user-id")));
+        } else if (request.getHeader("authority-id") != null){
+            validateByAuthorityId(authentication,Long.parseLong(request.getHeader("authority-id")));
+        } else {
             throw new CustomException(UNAUTHORIZED_REQUEST);
         }
     }
@@ -36,6 +36,17 @@ public class AuthorityCheckService {
 
         String nickname = principal.getUsername();
         if (!authority.getUser().getNickname().equals(nickname)) {
+            throw new CustomException(UNAUTHORIZED_REQUEST);
+        }
+    }
+
+    private void validateByUserId(Authentication authentication, Long userId) {
+        User principal = (User) authentication.getPrincipal();
+        com.newfit.reservation.domain.User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String nickname = principal.getUsername();
+        if (!user.getNickname().equals(nickname)) {
             throw new CustomException(UNAUTHORIZED_REQUEST);
         }
     }

--- a/src/main/java/com/newfit/reservation/controller/AuthorityApiController.java
+++ b/src/main/java/com/newfit/reservation/controller/AuthorityApiController.java
@@ -1,11 +1,13 @@
 package com.newfit.reservation.controller;
 
+import com.newfit.reservation.common.RequestHeaderUtil;
 import com.newfit.reservation.common.auth.AuthorityCheckService;
 import com.newfit.reservation.dto.request.AuthorityRequest;
 import com.newfit.reservation.dto.request.EntryRequest;
 import com.newfit.reservation.dto.response.GymListResponse;
 import com.newfit.reservation.dto.response.ReservationListResponse;
 import com.newfit.reservation.service.AuthorityService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +23,16 @@ import static org.springframework.http.HttpStatus.*;
 public class AuthorityApiController {
     private final AuthorityService authorityService;
     private final AuthorityCheckService authorityCheckService;
+    private final RequestHeaderUtil requestHeaderUtil;
 
     @PostMapping
     public ResponseEntity<Void> register(Authentication authentication,
-                                         @RequestHeader(value = "user-id") Long userId,
-                                         @Valid @RequestBody AuthorityRequest request,
-                                         HttpServletResponse response) {
-        authorityCheckService.validateByUserId(authentication, userId);
+                                         HttpServletRequest servletRequest,
+                                         HttpServletResponse response,
+                                         @Valid @RequestBody AuthorityRequest request) {
+        authorityCheckService.checkHeaderAndValidateAuthority(authentication, servletRequest);
+
+        Long userId = requestHeaderUtil.extractUserId(servletRequest);
         authorityService.register(userId, request.getGymId(), response);
 
         return ResponseEntity

--- a/src/main/java/com/newfit/reservation/controller/DevApiController.java
+++ b/src/main/java/com/newfit/reservation/controller/DevApiController.java
@@ -1,5 +1,6 @@
 package com.newfit.reservation.controller;
 
+import com.newfit.reservation.common.RequestHeaderUtil;
 import com.newfit.reservation.common.auth.AuthorityCheckService;
 import com.newfit.reservation.domain.User;
 import com.newfit.reservation.dto.request.CreateProposalRequest;
@@ -7,6 +8,7 @@ import com.newfit.reservation.dto.request.CreateReportRequest;
 import com.newfit.reservation.service.UserService;
 import com.newfit.reservation.service.dev.ProposalService;
 import com.newfit.reservation.service.dev.ReportService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,13 +25,15 @@ public class DevApiController {
     private final ProposalService proposalService;
     private final UserService userService;
     private final AuthorityCheckService authorityCheckService;
+    private final RequestHeaderUtil requestHeaderUtil;
 
     @PostMapping("/bug")
     public ResponseEntity<Void> createBugReport(Authentication authentication,
-                                                @RequestHeader(value = "user-id") Long userId,
+                                                HttpServletRequest servletRequest,
                                                 @Valid @RequestBody CreateReportRequest request) {
-        authorityCheckService.validateByUserId(authentication, userId);
+        authorityCheckService.checkHeaderAndValidateAuthority(authentication, servletRequest);
 
+        Long userId = requestHeaderUtil.extractUserId(servletRequest);
         User user = userService.findOneById(userId);
         reportService.saveReport(user, request);
 
@@ -40,10 +44,11 @@ public class DevApiController {
 
     @PostMapping("/feature")
     public ResponseEntity<Void> createFeatureProposal(Authentication authentication,
-                                                      @RequestHeader(value = "user-id") Long userId,
+                                                      HttpServletRequest servletRequest,
                                                       @Valid @RequestBody CreateProposalRequest request) {
-        authorityCheckService.validateByUserId(authentication, userId);
+        authorityCheckService.checkHeaderAndValidateAuthority(authentication, servletRequest);
 
+        Long userId = requestHeaderUtil.extractUserId(servletRequest);
         User user = userService.findOneById(userId);
         proposalService.saveProposal(user, request);
 

--- a/src/main/java/com/newfit/reservation/controller/UserApiController.java
+++ b/src/main/java/com/newfit/reservation/controller/UserApiController.java
@@ -1,10 +1,12 @@
 package com.newfit.reservation.controller;
 
+import com.newfit.reservation.common.RequestHeaderUtil;
 import com.newfit.reservation.common.auth.AuthorityCheckService;
 import com.newfit.reservation.dto.request.UserSignUpRequest;
 import com.newfit.reservation.dto.request.UserUpdateRequest;
 import com.newfit.reservation.dto.response.UserDetailResponse;
 import com.newfit.reservation.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +23,17 @@ public class UserApiController {
 
     private final UserService userService;
     private final AuthorityCheckService authorityCheckService;
+    private final RequestHeaderUtil requestHeaderUtil;
 
     @PatchMapping
     public ResponseEntity<Void> modify(Authentication authentication,
-                                       @RequestHeader(value = "user-id") Long userId,
+                                       HttpServletRequest servletRequest,
                                        @Valid @RequestBody UserUpdateRequest request) {
-        authorityCheckService.validateByUserId(authentication, userId);
+        authorityCheckService.checkHeaderAndValidateAuthority(authentication, servletRequest);
+
+        Long userId = requestHeaderUtil.extractUserId(servletRequest);
         userService.modify(userId, request);
+
         return ResponseEntity
                 .noContent()
                 .build();
@@ -42,9 +48,12 @@ public class UserApiController {
 
     @DeleteMapping
     public ResponseEntity<Void> drop(Authentication authentication,
-                                     @RequestHeader(value = "user-id") Long userId) {
-        authorityCheckService.validateByUserId(authentication, userId);
+                                     HttpServletRequest request) {
+        authorityCheckService.checkHeaderAndValidateAuthority(authentication, request);
+
+        Long userId = requestHeaderUtil.extractUserId(request);
         userService.drop(userId);
+
         return ResponseEntity
                 .noContent()
                 .build();


### PR DESCRIPTION
## 개요
- close #176 
## 작업사항
- AuthorityCheckService 내부에 현재 헤더에 담긴 값을 구분하여 validation 로직을 실행하는 
메소드 추가
- RequestHeaderUtil 생성
- AuthorityApiController, DevApiController, UserApiController에 변경 사항 반영