### PR TITLE
feat: User modify 실행 시 nickname 변경하면 JWT 새로 발급하는 로직 구현 (#177)

### DIFF
--- a/src/main/java/com/newfit/reservation/controller/UserApiController.java
+++ b/src/main/java/com/newfit/reservation/controller/UserApiController.java
@@ -24,10 +24,11 @@ public class UserApiController {
 
     @PatchMapping
     public ResponseEntity<Void> modify(Authentication authentication,
+                                       HttpServletResponse response,
                                        @RequestHeader(value = "user-id") Long userId,
                                        @Valid @RequestBody UserUpdateRequest request) {
         authorityCheckService.validateByUserId(authentication, userId);
-        userService.modify(userId, request);
+        userService.modify(userId, request, response);
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/com/newfit/reservation/exception/ErrorCode.java
+++ b/src/main/java/com/newfit/reservation/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     DUPLICATE_ROUTINE_NAME(HttpStatus.CONFLICT, "중복된 루틴 이름입니다."),
     ALREADY_TAGGED_RESERVATION(HttpStatus.CONFLICT, "이미 태그하였습니다."),
     MAXIMUM_CREDIT_LIMIT(HttpStatus.CONFLICT, "일일 크레딧 획득량을 모두 채웠습니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다.");

--- a/src/main/java/com/newfit/reservation/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/service/UserService.java
@@ -50,7 +50,10 @@ public class UserService {
             updateUser.updateFilePath(request.getUserProfileImage());
 
         if (request.getNickname() != null) {
-            updateUser.updateNickname(request.getNickname());
+            String nickname = request.getNickname();
+            validateDuplicateNickname(nickname);
+            updateUser.updateNickname(nickname);
+
             String accessToken = tokenProvider.generateAccessToken(updateUser);
             log.info("UserModify.accessToken = {}", accessToken);
             response.setHeader("access-token", accessToken);
@@ -103,5 +106,11 @@ public class UserService {
         String accessToken = tokenProvider.generateAccessToken(user);
         log.info("UserSignup.accessToken = {}", accessToken);
         response.setHeader("access-token", accessToken);
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        if (userRepository.findByNickname(nickname).isPresent()) {
+            throw new CustomException(DUPLICATE_NICKNAME);
+        }
     }
 }

--- a/src/main/java/com/newfit/reservation/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/service/UserService.java
@@ -37,20 +37,24 @@ public class UserService {
     private final OAuthHistoryRepository oAuthHistoryRepository;
     private final TokenProvider tokenProvider;
 
-    public void modify(Long userId, UserUpdateRequest request) {
+    public void modify(Long userId, UserUpdateRequest request, HttpServletResponse response) {
         User updateUser = findOneById(userId);
 
         if (request.getEmail() != null)
             updateUser.updateEmail(request.getEmail());
-
-        if (request.getNickname() != null)
-            updateUser.updateNickname(request.getNickname());
 
         if (request.getTel() != null)
             updateUser.updateTel(request.getTel());
 
         if (request.getUserProfileImage() != null)
             updateUser.updateFilePath(request.getUserProfileImage());
+
+        if (request.getNickname() != null) {
+            updateUser.updateNickname(request.getNickname());
+            String accessToken = tokenProvider.generateAccessToken(updateUser);
+            log.info("UserModify.accessToken = {}", accessToken);
+            response.setHeader("access-token", accessToken);
+        }
     }
 
     public UserDetailResponse userDetail(Long authorityId) {

--- a/src/main/java/com/newfit/reservation/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/service/UserService.java
@@ -99,6 +99,8 @@ public class UserService {
         OAuthHistory oAuthHistory = oAuthHistoryRepository
                 .findById(oauthHistoryId)
                 .orElseThrow(() -> new CustomException(OAUTH_HISTORY_NOT_FOUND));
+
+        validateDuplicateNickname(request.getNickname());
         User user = User.userSignUp(request);
         userRepository.save(user);
         oAuthHistory.signUp(user);


### PR DESCRIPTION
## 개요
- close #177 
## 작업사항
- UserApiController의 modify 메소드 매개변수 수정 및 UserService의 modify 메소드 호출 형식 수정
- UserService의 modify 메소드 내부에서 nickname 변경을 체크하고 JWT 새로 발급하는 로직 추가