### PR TITLE
refactor: 엔티티 delete 로직 내부에서 연관관계를 맺은 모든 엔티티들도 같이 삭제하도록 수정 (#178)

### DIFF
--- a/src/main/java/com/newfit/reservation/domain/Authority.java
+++ b/src/main/java/com/newfit/reservation/domain/Authority.java
@@ -50,10 +50,10 @@ public class Authority extends BaseTimeEntity {
     private LocalDateTime tagAt;
 
     // 양방향 연관관계를 나타냅니다.
-    @OneToMany(mappedBy = "authority", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "authority", cascade = CascadeType.REMOVE)
     private List<Credit> creditList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "authority", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "authority", cascade = CascadeType.REMOVE)
     private List<Reservation> reservationList = new ArrayList<>();
 
     // accepted 필드값을 true로 업데이트하는 메소드입니다.

--- a/src/main/java/com/newfit/reservation/domain/User.java
+++ b/src/main/java/com/newfit/reservation/domain/User.java
@@ -57,7 +57,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "file_path", nullable = false)
     private String filePath;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", cascade = CascadeType.REMOVE)
     private OAuthHistory oAuthHistory;
 
     // 양방향 연관관계를 나타냅니다.

--- a/src/main/java/com/newfit/reservation/domain/dev/Proposal.java
+++ b/src/main/java/com/newfit/reservation/domain/dev/Proposal.java
@@ -42,6 +42,10 @@ public class Proposal {
                 .build();
     }
 
+    public void removeUser() {
+        this.user = null;
+    }
+
     // 연관관계 편의 메소드입니다.
     public void setUserRelation(User user) {
         this.user = user;

--- a/src/main/java/com/newfit/reservation/domain/dev/Report.java
+++ b/src/main/java/com/newfit/reservation/domain/dev/Report.java
@@ -42,6 +42,10 @@ public class Report {
                 .build();
     }
 
+    public void removeUser() {
+        this.user = null;
+    }
+
     // 연관관계 편의 메소드입니다.
     public void setUserRelation(User user) {
         this.user = user;

--- a/src/main/java/com/newfit/reservation/repository/dev/ProposalRepository.java
+++ b/src/main/java/com/newfit/reservation/repository/dev/ProposalRepository.java
@@ -1,7 +1,11 @@
 package com.newfit.reservation.repository.dev;
 
+import com.newfit.reservation.domain.User;
 import com.newfit.reservation.domain.dev.Proposal;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+    List<Proposal> findAllByUser(User user);
 }

--- a/src/main/java/com/newfit/reservation/repository/dev/ReportRepository.java
+++ b/src/main/java/com/newfit/reservation/repository/dev/ReportRepository.java
@@ -1,7 +1,11 @@
 package com.newfit.reservation.repository.dev;
 
+import com.newfit.reservation.domain.User;
 import com.newfit.reservation.domain.dev.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    List<Report> findAllByUser(User user);
 }

--- a/src/main/java/com/newfit/reservation/repository/reservation/ReservationRepository.java
+++ b/src/main/java/com/newfit/reservation/repository/reservation/ReservationRepository.java
@@ -17,4 +17,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllByEquipmentGym(EquipmentGym equipmentGym);
 
     Optional<Reservation> findByAuthorityAndEquipmentGym(Authority authority, EquipmentGym equipmentGym);
+
+    void deleteAllByEquipmentGym(EquipmentGym equipmentGym);
 }

--- a/src/main/java/com/newfit/reservation/repository/routine/EquipmentRoutineRepository.java
+++ b/src/main/java/com/newfit/reservation/repository/routine/EquipmentRoutineRepository.java
@@ -1,5 +1,6 @@
 package com.newfit.reservation.repository.routine;
 
+import com.newfit.reservation.domain.equipment.Equipment;
 import com.newfit.reservation.domain.routine.EquipmentRoutine;
 import com.newfit.reservation.domain.routine.Routine;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,8 @@ public interface EquipmentRoutineRepository extends JpaRepository<EquipmentRouti
 
     // Routine의 모든 EquipmentRoutine 객체를 삭제
     void deleteAllByRoutine(Routine routine);
+
+    void deleteAllByEquipment(Equipment equipment);
 
     // Routine의 모든 EquipmentRoutine 객체를 조회
     List<EquipmentRoutine> findAllByRoutine(Routine routine);

--- a/src/main/java/com/newfit/reservation/repository/routine/RoutineRepository.java
+++ b/src/main/java/com/newfit/reservation/repository/routine/RoutineRepository.java
@@ -11,4 +11,6 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     Optional<Routine> findByAuthorityAndName(Authority authority, String name);
 
     List<Routine> findAllByAuthority(Authority authority);
+
+    void deleteAllByAuthority(Authority authority);
 }

--- a/src/main/java/com/newfit/reservation/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/service/AuthorityService.java
@@ -5,6 +5,7 @@ import com.newfit.reservation.domain.Authority;
 import com.newfit.reservation.domain.Gym;
 import com.newfit.reservation.domain.Role;
 import com.newfit.reservation.domain.User;
+import com.newfit.reservation.domain.routine.Routine;
 import com.newfit.reservation.dto.request.EntryRequest;
 import com.newfit.reservation.dto.response.*;
 import com.newfit.reservation.exception.CustomException;
@@ -12,6 +13,7 @@ import com.newfit.reservation.repository.AuthorityRepository;
 import com.newfit.reservation.repository.GymRepository;
 import com.newfit.reservation.repository.UserRepository;
 import com.newfit.reservation.repository.reservation.ReservationRepository;
+import com.newfit.reservation.repository.routine.RoutineRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class AuthorityService {
     private final GymRepository gymRepository;
     private final ReservationRepository reservationRepository;
     private final TokenProvider tokenProvider;
+    private final RoutineRepository routineRepository;
 
     public void register(Long userId, Long gymId, HttpServletResponse response) {
 
@@ -52,7 +55,9 @@ public class AuthorityService {
     public void delete(Long authorityId, HttpServletResponse response) {
         Authority authority = authorityRepository.findById(authorityId).orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
         User user = authority.getUser();
+        List<Routine> routines = routineRepository.findAllByAuthority(authority);
 
+        routineRepository.deleteAll(routines);
         user.getAuthorityList().remove(authority);
         authorityRepository.delete(authority);
 

--- a/src/main/java/com/newfit/reservation/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/service/AuthorityService.java
@@ -53,11 +53,10 @@ public class AuthorityService {
     }
 
     public void delete(Long authorityId, HttpServletResponse response) {
-        Authority authority = authorityRepository.findById(authorityId).orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
+        Authority authority = findById(authorityId);
         User user = authority.getUser();
-        List<Routine> routines = routineRepository.findAllByAuthority(authority);
 
-        routineRepository.deleteAll(routines);
+        routineRepository.deleteAllByAuthority(authority);
         user.getAuthorityList().remove(authority);
         authorityRepository.delete(authority);
 

--- a/src/main/java/com/newfit/reservation/service/equipment/EquipmentGymService.java
+++ b/src/main/java/com/newfit/reservation/service/equipment/EquipmentGymService.java
@@ -9,6 +9,7 @@ import com.newfit.reservation.dto.response.EquipmentGymListResponse;
 import com.newfit.reservation.dto.response.EquipmentResponse;
 import com.newfit.reservation.exception.CustomException;
 import com.newfit.reservation.repository.equipment.EquipmentGymRepository;
+import com.newfit.reservation.repository.reservation.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import static com.newfit.reservation.exception.ErrorCode.*;
 public class EquipmentGymService {
 
     private final EquipmentGymRepository equipmentGymRepository;
+    private final ReservationRepository reservationRepository;
 
     /*
     입력받은 개수(count)만큼 등록
@@ -61,6 +63,9 @@ public class EquipmentGymService {
     equipmentGym 삭제
      */
     public void deleteEquipmentGym(Long equipmentGymId) {
+        EquipmentGym equipmentGym = findOneById(equipmentGymId);
+
+        reservationRepository.deleteAllByEquipmentGym(equipmentGym);
         equipmentGymRepository.deleteById(equipmentGymId);
     }
 

--- a/src/main/java/com/newfit/reservation/service/equipment/EquipmentService.java
+++ b/src/main/java/com/newfit/reservation/service/equipment/EquipmentService.java
@@ -5,6 +5,7 @@ import com.newfit.reservation.domain.equipment.Equipment;
 import com.newfit.reservation.domain.equipment.Purpose;
 import com.newfit.reservation.exception.CustomException;
 import com.newfit.reservation.repository.equipment.EquipmentRepository;
+import com.newfit.reservation.repository.routine.EquipmentRoutineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import static com.newfit.reservation.exception.ErrorCode.*;
 @Transactional
 public class EquipmentService {
     private final EquipmentRepository equipmentRepository;
+    private final EquipmentRoutineRepository equipmentRoutineRepository;
 
     /*
     Equipment를 새로 등록.
@@ -41,6 +43,9 @@ public class EquipmentService {
     equipment 삭제
      */
     public void deleteEquipment(Long equipmentId) {
+        Equipment equipment = findById(equipmentId);
+
+        equipmentRoutineRepository.deleteAllByEquipment(equipment);
         equipmentRepository.deleteById(equipmentId);
     }
 


### PR DESCRIPTION
## 개요
- close #178 
## 작업사항
- User 삭제 -> Authority , OAuthHistory, RefreshToken 삭제 (+ Report, Proposal에서는 User 필드를 null로 변경)
- Authority 삭제 -> Credit, Routine 삭제, Reservation의 authorityId는 null로 변경
- Routine 삭제 -> EquipmentRoutine 삭제
- Equipment 비활성화 -> EquipmentRoutine, EquipmentGym 비활성화
- EquipmentGym 비활성화 기능 추가