### PR TITLE
refactor: ReservationService를 분리 (#187)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/credit/service/CreditService.java
+++ b/src/main/java/com/newfit/reservation/domains/credit/service/CreditService.java
@@ -3,17 +3,20 @@ package com.newfit.reservation.domains.credit.service;
 import com.newfit.reservation.common.exception.CustomException;
 import com.newfit.reservation.domains.authority.domain.Authority;
 import com.newfit.reservation.domains.authority.repository.AuthorityRepository;
+import com.newfit.reservation.domains.credit.domain.Credit;
 import com.newfit.reservation.domains.credit.dto.response.CreditRanking;
 import com.newfit.reservation.domains.credit.dto.response.UserRankInfo;
 import com.newfit.reservation.domains.credit.dto.response.UserRankInfoListResponse;
 import com.newfit.reservation.domains.credit.repository.CreditRepository;
+import com.newfit.reservation.domains.reservation.domain.Reservation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.newfit.reservation.common.exception.ErrorCode.AUTHORITY_NOT_FOUND;
+import static com.newfit.reservation.common.exception.ErrorCode.*;
+import static java.time.LocalDateTime.now;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +27,7 @@ public class CreditService {
     private final AuthorityRepository authorityRepository;
 
     public UserRankInfoListResponse getRankInGym(Long authorityId) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = now();
         Authority authority = authorityRepository.findById(authorityId)
                 .orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
 
@@ -45,5 +48,37 @@ public class CreditService {
                 .orElseGet(() -> UserRankInfo.noCredit(authority));
 
         return new UserRankInfoListResponse(authority.getGym().getName(), rankingList, userRankInfo);
+    }
+
+    public void checkConditionAndAddCredit(Reservation reservation, Authority authority, LocalDateTime endEquipmentUseAt) {
+        LocalDateTime now = now();
+
+        if (checkConditions(reservation, endEquipmentUseAt)) {
+            if (authority.getCreditAcquisitionCount() != 10) {
+                Credit credit = creditRepository.findByAuthorityAndYearAndMonth(authority, (short) now.getYear(), (short) now.getMonthValue())
+                        .orElseGet(() -> creditRepository.save(Credit.createCredit(authority)));
+                credit.addAmount();
+                authority.incrementAcquisitionCount();
+                authority.getUser().addBalance(100L);
+            } else {
+                throw new CustomException(MAXIMUM_CREDIT_LIMIT);
+            }
+        } else {
+            throw new CustomException(INVALID_CREDIT_ACQUIRE_REQUEST, "크레딧 획득에 실패했습니다.");
+        }
+    }
+
+    private boolean checkConditions(Reservation reservation, LocalDateTime endTagAt) {
+        return isStartTagInTime(reservation) && isEndTagInTime(reservation, endTagAt);
+    }
+
+    private boolean isStartTagInTime(Reservation reservation) {
+        return (reservation.getStartTagAt().isBefore(reservation.getStartAt().plusMinutes(5)) && reservation.getStartTagAt().isAfter(reservation.getStartAt()))
+                || reservation.getStartTagAt().isEqual(reservation.getStartAt().plusMinutes(5));
+    }
+
+    private boolean isEndTagInTime(Reservation reservation, LocalDateTime endTagAt) {
+        return (endTagAt.isBefore(reservation.getEndAt().plusMinutes(5)) && endTagAt.isAfter(reservation.getEndAt()))
+                || endTagAt.isEqual(reservation.getEndAt().plusMinutes(5));
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/equipment/repository/EquipmentGymRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/repository/EquipmentGymRepository.java
@@ -6,12 +6,24 @@ import com.newfit.reservation.domains.gym.domain.Gym;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface EquipmentGymRepository extends JpaRepository<EquipmentGym, Long> {
     List<EquipmentGym> findAllByGym(Gym gym);
 
-    @Query("select e from EquipmentGym e where e.equipment.id = :equipmentId")
-    List<EquipmentGym> findAvailableByEquipmentId(@Param("equipmentId") Long equipmentId);
+    @Query(value = "SELECT * " +
+                   "FROM Equipment_Gym eg " +
+                   "WHERE eg.equipment_id = :equipmentId" +
+                   "  AND NOT EXISTS (" +
+                   "    SELECT 1 FROM Reservation r" +
+                   "    WHERE r.equipment_gym_id = eg.id AND " +
+                   "        ((:startAt BETWEEN r.start_at AND r.end_at)" +
+                   "        OR (:endAt BETWEEN r.start_at AND r.end_at)" +
+                   "        OR (:startAt <= r.start_at AND r.end_at <= :endAt))) " +
+                   "LIMIT 1;", nativeQuery = true)
+    Optional<EquipmentGym> findAvailableByEquipmentIdAndStartAtAndEndAt(@Param("equipmentId") Long equipmentId,
+                                                                        @Param("startAt") LocalDateTime startAt,
+                                                                        @Param("endAt") LocalDateTime endAt);
 }

--- a/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
@@ -4,6 +4,7 @@ import com.newfit.reservation.common.auth.AuthorityCheckService;
 import com.newfit.reservation.domains.authority.domain.Authority;
 import com.newfit.reservation.domains.authority.service.AuthorityService;
 import com.newfit.reservation.domains.credit.dto.request.ObtainCreditRequest;
+import com.newfit.reservation.domains.credit.service.CreditService;
 import com.newfit.reservation.domains.reservation.domain.Reservation;
 import com.newfit.reservation.domains.reservation.dto.request.ReservationRequest;
 import com.newfit.reservation.domains.reservation.dto.request.ReservationUpdateRequest;
@@ -28,9 +29,10 @@ import static org.springframework.http.HttpStatus.CREATED;
 @RequiredArgsConstructor
 public class ReservationApiController {
 
-    private final ReservationService reservationService;
     private final AuthorityService authorityService;
     private final AuthorityCheckService authorityCheckService;
+    private final CreditService creditService;
+    private final ReservationService reservationService;
 
     @PostMapping
     public ResponseEntity<Void> reserve(Authentication authentication,
@@ -108,7 +110,7 @@ public class ReservationApiController {
         Authority authority = authorityService.findById(authorityId);
 
         reservationService.updateStatusAndCondition(reservation);
-        reservationService.checkConditionAndAddCredit(reservation, authority, request.getEndEquipmentUseAt());
+        creditService.checkConditionAndAddCredit(reservation, authority, request.getEndEquipmentUseAt());
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
@@ -13,6 +13,7 @@ import com.newfit.reservation.domains.reservation.dto.response.ReservationListRe
 import com.newfit.reservation.domains.reservation.service.ReservationService;
 import com.newfit.reservation.domains.routine.dto.request.RoutineReservationRequest;
 import com.newfit.reservation.domains.routine.dto.response.RoutineReservationListResponse;
+import com.newfit.reservation.domains.routine.service.RoutineService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ public class ReservationApiController {
     private final AuthorityCheckService authorityCheckService;
     private final CreditService creditService;
     private final ReservationService reservationService;
+    private final RoutineService routineService;
 
     @PostMapping
     public ResponseEntity<Void> reserve(Authentication authentication,
@@ -81,8 +83,7 @@ public class ReservationApiController {
                                                                            @PathVariable Long routineId,
                                                                            @Valid @RequestBody RoutineReservationRequest request) {
         authorityCheckService.validateByAuthorityId(authentication, authorityId);
-
-        RoutineReservationListResponse response = reservationService.reserveByRoutine(authorityId, routineId, request.getStartAt());
+        RoutineReservationListResponse response = routineService.reserveByRoutine(authorityId, routineId, request.getStartAt());
 
         return ResponseEntity
                 .status(CREATED)


### PR DESCRIPTION
## 개요
- close #187 
## 작업사항
- 크레딧에 대한 로직을 CreditService로 이동
- 루틴으로 예약하는 로직을 RoutineService로 이동 
- getOneAvailable 메서드를 쿼리로 개선