### PR TITLE
chore: dto 내부에 있는 id 필드를 구체적인 이름으로 변경 (#218)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/authority/dto/response/ReservationResponse.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/dto/response/ReservationResponse.java
@@ -11,9 +11,9 @@ import lombok.NoArgsConstructor;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationResponse {
-    private Long id;
+    private Long reservationId;
 
-    public ReservationResponse(Long id) {
-        this.id = id;
+    public ReservationResponse(Long reservationId) {
+        this.reservationId = reservationId;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/dto/response/ReservationResponse.java
@@ -11,9 +11,9 @@ import lombok.NoArgsConstructor;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationResponse {
-    private Long id;
+    private Long reservationId;
 
-    public ReservationResponse(Long id) {
-        this.id = id;
+    public ReservationResponse(Long reservationId) {
+        this.reservationId = reservationId;
     }
 }


### PR DESCRIPTION
## 개요
- close #218 
## 작업사항
- authority 패키지의 ReservationResponse 내부 id를 reservationId로 변경
- reservation 패키지의 ReservationResponse 내부 id를 reservationId로 변경