### PR TITLE
refactor: 예약 등록 및 수정 api endpoint에서 param을 pathvariable로 수정 (#234)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
@@ -38,10 +38,10 @@ public class ReservationApiController {
     private final ReservationService reservationService;
     private final RoutineService routineService;
 
-    @PostMapping
+    @PostMapping("/{equipmentId}")
     public ResponseEntity<Void> reserve(Authentication authentication,
                                         @RequestHeader("authority-id") Long authorityId,
-                                        @RequestParam(value = "equipment_id") Long equipmentId,
+                                        @PathVariable("equipmentId") Long equipmentId,
                                         @Valid @RequestBody ReservationRequest request) {
         authorityCheckService.validateByAuthorityId(authentication, authorityId);
         reservationService.reserve(authorityId, equipmentId, request);

--- a/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/controller/ReservationApiController.java
@@ -58,10 +58,10 @@ public class ReservationApiController {
                 .ok(reservationListResponse);
     }
 
-    @PatchMapping
+    @PatchMapping("/{reservationId}")
     public ResponseEntity<Void> updateReservation(Authentication authentication,
                                                   @RequestHeader("authority-id") Long authorityId,
-                                                  @RequestParam("reservation_id") Long reservationId,
+                                                  @PathVariable("reservationId") Long reservationId,
                                                   @Valid @RequestBody ReservationUpdateRequest request) {
         authorityCheckService.validateByAuthorityId(authentication, authorityId);
         reservationService.update(reservationId, request);


### PR DESCRIPTION
## 개요
- close #234 
## 작업사항
- ReservationApiController reserve 메소드의 RequestParam을 PathVariable로 변경
- ReservationApiController updateReservation 메소드의 RequestParam을 PathVariable로 변경