### PR TITLE
chore: AuthorityApiController listReservation 메소드의 endpoint 수정 (#235)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/authority/controller/AuthorityApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/controller/AuthorityApiController.java
@@ -54,7 +54,7 @@ public class AuthorityApiController {
                 .build();
     }
 
-    @GetMapping("/reservation")
+    @GetMapping("/reservations")
     public ResponseEntity<ReservationListResponse> listReservation(@RequestHeader("authority-id") Long authorityId) {
 
         ReservationListResponse reservationListResponse = authorityService.listAuthorityReservation(authorityId);


### PR DESCRIPTION
## 개요
- close #235 
## 작업사항
- AuthorityApiController listReservation 메소드 endpoint를 ~/reservation -> ~/reservations로 변경