### PR TITLE
feat: User drop 메소드 내부에 사용자 이메일을 통한 본인 확인 로직 추가 (#237)

### DIFF
--- a/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
+++ b/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     ALREADY_EXISTING_EQUIPMENT(HttpStatus.CONFLICT, "이미 존재하는 기구입니다."),
     MAXIMUM_CREDIT_LIMIT(HttpStatus.CONFLICT, "일일 크레딧 획득량을 모두 채웠습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
+    USER_EMAIL_VERIFICATION_FAIL(HttpStatus.CONFLICT, "이메일이 일치하지 않습니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다.");

--- a/src/main/java/com/newfit/reservation/domains/user/controller/UserApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/user/controller/UserApiController.java
@@ -1,6 +1,7 @@
 package com.newfit.reservation.domains.user.controller;
 
 import com.newfit.reservation.common.auth.AuthorityCheckService;
+import com.newfit.reservation.domains.user.dto.request.UserDropRequest;
 import com.newfit.reservation.domains.user.dto.request.UserSignUpRequest;
 import com.newfit.reservation.domains.user.dto.request.UserUpdateRequest;
 import com.newfit.reservation.domains.user.dto.response.UserInfoResponse;
@@ -44,9 +45,10 @@ public class UserApiController {
 
     @DeleteMapping
     public ResponseEntity<Void> drop(Authentication authentication,
-                                     @RequestHeader(value = "user-id") Long userId) {
+                                     @RequestHeader(value = "user-id") Long userId,
+                                     @Valid @RequestBody UserDropRequest request) {
         authorityCheckService.validateByUserId(authentication, userId);
-        userService.drop(userId);
+        userService.drop(userId, request.getEmail());
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/com/newfit/reservation/domains/user/domain/User.java
+++ b/src/main/java/com/newfit/reservation/domains/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.newfit.reservation.domains.user.domain;
 
+import com.newfit.reservation.common.exception.CustomException;
 import com.newfit.reservation.common.model.BaseTimeEntity;
 import com.newfit.reservation.domains.auth.domain.OAuthHistory;
 import com.newfit.reservation.domains.authority.domain.Authority;
@@ -15,6 +16,8 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.newfit.reservation.common.exception.ErrorCode.USER_EMAIL_VERIFICATION_FAIL;
 
 @Entity
 @Getter
@@ -107,6 +110,12 @@ public class User extends BaseTimeEntity {
                 .map(authority -> authority.getTermCredit(term))
                 .mapToLong(Long::longValue)
                 .sum();
+    }
+
+    public void verifyByEmail(String email) {
+        if (!email.equals(this.email)) {
+            throw new CustomException(USER_EMAIL_VERIFICATION_FAIL);
+        }
     }
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/newfit/reservation/domains/user/dto/request/UserDropRequest.java
+++ b/src/main/java/com/newfit/reservation/domains/user/dto/request/UserDropRequest.java
@@ -1,0 +1,14 @@
+package com.newfit.reservation.domains.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDropRequest {
+
+    @Email
+    private String email;
+}

--- a/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
@@ -90,8 +90,12 @@ public class UserService {
                 .orElse(0L);
     }
 
-    public void drop(Long userId) {
-        userRepository.deleteById(userId);
+    public void drop(Long userId, String email) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        if (!user.getEmail().equals(email)) {
+            throw new CustomException(USER_EMAIL_VERIFICATION_FAIL);
+        }
+        userRepository.delete(user);
     }
 
     public User findOneById(Long userId) {

--- a/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
@@ -92,9 +92,7 @@ public class UserService {
 
     public void drop(Long userId, String email) {
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-        if (!user.getEmail().equals(email)) {
-            throw new CustomException(USER_EMAIL_VERIFICATION_FAIL);
-        }
+        user.verifyByEmail(email);
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
## 개요
- close #237 
## 작업사항
- UserDropRequest 클래스 생성
- ErrorCode에 USER_EMAIL_VERIFICATION_FAIL 추가
- UserService drop 메소드 내부에 사용자 이메일을 통한 본인 확인 로직 추가
- UserApiController drop 메소드에 변경 사항 반영