### PR TITLE
refactor: Authority의 accepted가 false인 경우 authority-id가 필요한 api 접근을 제한하도록 수정 (#245)

### DIFF
--- a/src/main/java/com/newfit/reservation/common/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/newfit/reservation/common/auth/config/WebSecurityConfig.java
@@ -3,10 +3,11 @@ package com.newfit.reservation.common.auth.config;
 import com.newfit.reservation.common.auth.jwt.TokenAuthenticationFilter;
 import com.newfit.reservation.common.auth.jwt.TokenProvider;
 import com.newfit.reservation.common.auth.oauth.OAuth2AuthorizationRequestCookieRepository;
+import com.newfit.reservation.common.auth.oauth.OAuth2UserCustomService;
 import com.newfit.reservation.common.auth.oauth.handler.OAuth2FailureHandler;
 import com.newfit.reservation.common.auth.oauth.handler.OAuth2SuccessHandler;
-import com.newfit.reservation.common.auth.oauth.OAuth2UserCustomService;
 import com.newfit.reservation.domains.auth.repository.RefreshTokenRepository;
+import com.newfit.reservation.domains.authority.repository.AuthorityRepository;
 import com.newfit.reservation.domains.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class WebSecurityConfig {
 
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
+    private final AuthorityRepository authorityRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final OAuth2UserCustomService oAuth2UserCustomService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
@@ -79,7 +81,7 @@ public class WebSecurityConfig {
 
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(tokenProvider, refreshTokenRepository, userRepository);
+        return new TokenAuthenticationFilter(tokenProvider, refreshTokenRepository, userRepository, authorityRepository);
     }
 
     @Bean

--- a/src/main/java/com/newfit/reservation/common/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/newfit/reservation/common/auth/config/WebSecurityConfig.java
@@ -1,13 +1,14 @@
 package com.newfit.reservation.common.auth.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newfit.reservation.common.auth.jwt.TokenAuthenticationFilter;
 import com.newfit.reservation.common.auth.jwt.TokenProvider;
 import com.newfit.reservation.common.auth.oauth.OAuth2AuthorizationRequestCookieRepository;
 import com.newfit.reservation.common.auth.oauth.OAuth2UserCustomService;
 import com.newfit.reservation.common.auth.oauth.handler.OAuth2FailureHandler;
 import com.newfit.reservation.common.auth.oauth.handler.OAuth2SuccessHandler;
+import com.newfit.reservation.common.exception.CustomExceptionHandlingFilter;
 import com.newfit.reservation.domains.auth.repository.RefreshTokenRepository;
-import com.newfit.reservation.domains.authority.repository.AuthorityRepository;
 import com.newfit.reservation.domains.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -32,11 +33,11 @@ public class WebSecurityConfig {
 
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
-    private final AuthorityRepository authorityRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final OAuth2UserCustomService oAuth2UserCustomService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final ObjectMapper objectMapper;
 
     // 누구나 접근할 수 있는 URI 패턴을 정의
     private static final String[] PERMIT_ALL_PATTERNS = new String[] {
@@ -64,6 +65,7 @@ public class WebSecurityConfig {
                     .requestMatchers(AntPathRequestMatcher.antMatcher("/api/**")).authenticated()
                     .anyRequest().permitAll())
                 .addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(customExceptionHandlingFilter(), TokenAuthenticationFilter.class)
                 .oauth2Login(oauth -> oauth
                     .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint.userService(oAuth2UserCustomService))
                     .successHandler(oAuth2SuccessHandler)
@@ -81,12 +83,17 @@ public class WebSecurityConfig {
 
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(tokenProvider, refreshTokenRepository, userRepository, authorityRepository);
+        return new TokenAuthenticationFilter(tokenProvider, refreshTokenRepository, userRepository);
     }
 
     @Bean
     public OAuth2AuthorizationRequestCookieRepository oAuth2AuthorizationRequestCookieRepository() {
         return new OAuth2AuthorizationRequestCookieRepository();
+    }
+
+    @Bean
+    public CustomExceptionHandlingFilter customExceptionHandlingFilter() {
+        return new CustomExceptionHandlingFilter(objectMapper);
     }
 
     private String getToken(HttpServletRequest request) {

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenAuthenticationFilter.java
@@ -24,6 +24,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     // 수신한 JWT가 Bearer 타입인지 체크하기 위한 필드
     private final static String BEARER = "Bearer ";
+
     private final TokenProvider tokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
@@ -39,7 +40,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             String accessToken = reIssueAccessToken(token);
             response.setHeader("access-token", accessToken);
         } else if (request.getHeader("authority-id") != null) {
-            tokenProvider.validAccessToken(token, request);
+            tokenProvider.validAccessToken(token, request, response);
             Authentication authentication = tokenProvider.getAuthentication(token, request);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             filterChain.doFilter(request, response);

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -98,7 +98,7 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
     }
 
     private void checkExceptionAndProceed(HttpServletResponse response, CustomException exception, Long userId){
-        if (!exception.getErrorCode().equals(OUTDATED_TOKEN)) {
+        if (!exception.getErrorCode().equals(UPDATE_NEEDED_ON_AUTHORITY_ID_LIST)) {
             throw exception;
         }
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -134,7 +134,7 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
                     .orElseThrow(() -> new CustomException(UNAUTHORIZED_REQUEST));
 
             // JWT 새로 발급해야 하는 경우
-            throw new CustomException(OUTDATED_TOKEN);
+            throw new CustomException(UPDATE_NEEDED_ON_AUTHORITY_ID_LIST);
         }
     }
 

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -7,21 +7,26 @@ import com.newfit.reservation.domains.authority.domain.Authority;
 import com.newfit.reservation.domains.authority.domain.Role;
 import com.newfit.reservation.domains.authority.repository.AuthorityRepository;
 import com.newfit.reservation.domains.user.domain.User;
-import io.jsonwebtoken.*;
+import com.newfit.reservation.domains.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
+import java.io.IOException;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static com.newfit.reservation.common.exception.ErrorCode.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래스
@@ -32,6 +37,7 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
     private final JwtProperties jwtProperties;
     private final AuthorityRepository authorityRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
 
     public String generateAccessToken(User user) {
         Date now = new Date();
@@ -83,9 +89,26 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
                 .getToken();
     }
 
-    public void validAccessToken(String token, HttpServletRequest request) {
+    public void validAccessToken(String token, HttpServletRequest request, HttpServletResponse response) throws IOException {
         validToken(token);
-        checkAuthorityIdList(token, request);
+        try {
+            checkAuthorityIdList(token, request);
+        } catch (CustomException exception) {
+            checkExceptionAndProceed(request, response, exception, token);
+        }
+    }
+
+    private void checkExceptionAndProceed(HttpServletRequest request, HttpServletResponse response,
+                                          CustomException exception, String token) throws IOException {
+        if (!exception.getErrorCode().equals(OUTDATED_TOKEN)) {
+            throw exception;
+        }
+        Long userId = getUserId(token);
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String accessToken = generateAccessToken(user);
+        log.info("AcceptedUser.accessToken = {}", accessToken);
+        response.setHeader("access-token", accessToken);
     }
 
     public void validToken(String token) {
@@ -100,17 +123,36 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
      */
     private void checkAuthorityIdList(String token, HttpServletRequest request) {
         List<Integer> authorityIdList = getAuthorityIdList(token);
-        Integer authorityId = authorityRepository.findById(Long.parseLong(request.getHeader("authority-id"))).orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND)).getId().intValue();
-        authorityIdList
-                .stream()
-                .filter(authority -> authority.equals(authorityId))
-                .findAny()
-                .orElseThrow(() -> new CustomException(UNAUTHORIZED_REQUEST));
+        Long authorityId = extractAuthorityId(request);
+
+        if (!authorityIdList.contains(authorityId.intValue())) {
+            // token에 있는 userId로 User 조회
+            User user = userRepository.findById(getUserId(token))
+                    .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+            // findAny로 찾지 못함 == 아직 accept 되지 않음 or 헤더에 넣은 것이 자신의 authority-id가 아님
+            user.getAuthorityList().stream()
+                    .filter(authority -> authority.getId().equals(authorityId) && authority.getAccepted())
+                    .findAny()
+                    .orElseThrow(() -> new CustomException(UNAUTHORIZED_REQUEST));
+
+            // JWT 새로 발급해야 하는 경우
+            throw new CustomException(OUTDATED_TOKEN);
+        }
+    }
+
+    private Long getUserId(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("id", Long.class);
+    }
+
+    private Long extractAuthorityId(HttpServletRequest request) {
+        return Long.parseLong(request.getHeader("authority-id"));
     }
 
     public Authentication getAuthentication(String token, HttpServletRequest request) {
         Claims claims = getClaims(token);
-        Authority authority = authorityRepository.findById(Long.parseLong(request.getHeader("authority-id")))
+        Authority authority = authorityRepository.findById(extractAuthorityId(request))
                 .orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(authority.getRole().getDescription()));
 

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -20,7 +20,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.*;
 

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -94,12 +94,11 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
         try {
             checkAuthorityIdList(token, request);
         } catch (CustomException exception) {
-            checkExceptionAndProceed(request, response, exception, token);
+            checkExceptionAndProceed(response, exception, token);
         }
     }
 
-    private void checkExceptionAndProceed(HttpServletRequest request, HttpServletResponse response,
-                                          CustomException exception, String token) throws IOException {
+    private void checkExceptionAndProceed(HttpServletResponse response, CustomException exception, String token){
         if (!exception.getErrorCode().equals(OUTDATED_TOKEN)) {
             throw exception;
         }

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -89,7 +89,7 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
                 .getToken();
     }
 
-    public void validAccessToken(String token, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public void validAccessToken(String token, HttpServletRequest request, HttpServletResponse response) {
         validToken(token);
         try {
             checkAuthorityIdList(token, request);

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -98,7 +98,7 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
     }
 
     private void checkExceptionAndProceed(HttpServletResponse response, CustomException exception, Long userId){
-        if (!exception.getErrorCode().equals(UPDATE_NEEDED_ON_AUTHORITY_ID_LIST)) {
+        if (!exception.getErrorCode().equals(AUTHORITY_ID_LIST_OUTDATED)) {
             throw exception;
         }
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -134,7 +134,7 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
                     .orElseThrow(() -> new CustomException(UNAUTHORIZED_REQUEST));
 
             // JWT 새로 발급해야 하는 경우
-            throw new CustomException(UPDATE_NEEDED_ON_AUTHORITY_ID_LIST);
+            throw new CustomException(AUTHORITY_ID_LIST_OUTDATED);
         }
     }
 

--- a/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/newfit/reservation/common/auth/jwt/TokenProvider.java
@@ -93,15 +93,14 @@ public class TokenProvider {    // JWT의 생성 및 검증 로직 담당 클래
         try {
             checkAuthorityIdList(token, request);
         } catch (CustomException exception) {
-            checkExceptionAndProceed(response, exception, token);
+            checkExceptionAndProceed(response, exception, getUserId(token));
         }
     }
 
-    private void checkExceptionAndProceed(HttpServletResponse response, CustomException exception, String token){
+    private void checkExceptionAndProceed(HttpServletResponse response, CustomException exception, Long userId){
         if (!exception.getErrorCode().equals(OUTDATED_TOKEN)) {
             throw exception;
         }
-        Long userId = getUserId(token);
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         String accessToken = generateAccessToken(user);

--- a/src/main/java/com/newfit/reservation/common/exception/CustomExceptionHandlingFilter.java
+++ b/src/main/java/com/newfit/reservation/common/exception/CustomExceptionHandlingFilter.java
@@ -1,0 +1,28 @@
+package com.newfit.reservation.common.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class CustomExceptionHandlingFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request,response);
+        } catch (CustomException exception) {
+            ExceptionResponse exceptionResponse = ExceptionResponse.create(exception);
+            response.setContentType("application/json;charset=utf-8");
+            response.setStatus(exception.getErrorCode().getStatusCode());
+            objectMapper.writeValue(response.getWriter(), exceptionResponse);
+        }
+    }
+}

--- a/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
+++ b/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     ALREADY_EXISTING_EQUIPMENT(HttpStatus.CONFLICT, "이미 존재하는 기구입니다."),
     MAXIMUM_CREDIT_LIMIT(HttpStatus.CONFLICT, "일일 크레딧 획득량을 모두 채웠습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
+    OUTDATED_TOKEN(HttpStatus.CONFLICT, "사용자 변경 사항이 반영되지 않은 토큰입니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다.");

--- a/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
+++ b/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     ALREADY_EXISTING_EQUIPMENT(HttpStatus.CONFLICT, "이미 존재하는 기구입니다."),
     MAXIMUM_CREDIT_LIMIT(HttpStatus.CONFLICT, "일일 크레딧 획득량을 모두 채웠습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
-    OUTDATED_TOKEN(HttpStatus.CONFLICT, "사용자 변경 사항이 반영되지 않은 토큰입니다."),
+    UPDATE_NEEDED_ON_AUTHORITY_ID_LIST(HttpStatus.CONFLICT, "사용자 변경 사항이 반영되지 않은 토큰입니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다.");

--- a/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
+++ b/src/main/java/com/newfit/reservation/common/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     ALREADY_EXISTING_EQUIPMENT(HttpStatus.CONFLICT, "이미 존재하는 기구입니다."),
     MAXIMUM_CREDIT_LIMIT(HttpStatus.CONFLICT, "일일 크레딧 획득량을 모두 채웠습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
-    UPDATE_NEEDED_ON_AUTHORITY_ID_LIST(HttpStatus.CONFLICT, "사용자 변경 사항이 반영되지 않은 토큰입니다."),
+    AUTHORITY_ID_LIST_OUTDATED(HttpStatus.CONFLICT, "토큰의 AuthorityIdList에 변경 사항이 있습니다"),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다.");

--- a/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
@@ -49,7 +49,7 @@ public class AuthorityService {
 
         Authority authority = authorityRepository.save(Authority.createAuthority(user, gym));
 
-        response.setHeader("authority-id", authority.getId().toString());
+        response.setHeader("authority-id", String.valueOf(authority.getId()));
     }
 
     public void delete(Long authorityId, HttpServletResponse response) {

--- a/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
@@ -48,11 +48,8 @@ public class AuthorityService {
                 .orElseThrow(() -> new CustomException(GYM_NOT_FOUND));
 
         Authority authority = authorityRepository.save(Authority.createAuthority(user, gym));
-        user.getAuthorityList().add(authority);
 
-        String accessToken = tokenProvider.generateAccessToken(user);
-        log.info("AuthorityRegister.accessToken = {}", accessToken);
-        response.setHeader("access-token", accessToken);
+        response.setHeader("authority-id", authority.getId().toString());
     }
 
     public void delete(Long authorityId, HttpServletResponse response) {


### PR DESCRIPTION
## 개요
- close #245 
## 작업사항
- AuthorityService register 메소드 내부에서 JWT 발급하는 로직 제거
- ErrorCode에 OUTDATED_TOKEN 추가
- CustomExceptionHandlingFilter 생성
- TokenProvider 로직 수정 및 메소드 분리