### PR TITLE
refactor: 엔티티 delete 로직 내부에서 연관관계를 맺은 모든 엔티티들도 같이 삭제하도록 수정 (#178)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/authority/controller/ManagerApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/controller/ManagerApiController.java
@@ -93,11 +93,11 @@ public class ManagerApiController {
     특정 EquipmentGym 삭제
      */
     @DeleteMapping("/equipment-gym")
-    public ResponseEntity<Void> deleteEquipmentGym(Authentication authentication,
+    public ResponseEntity<Void> deactivateEquipmentGym(Authentication authentication,
                                                    @RequestHeader("authority-id") Long authorityId,
                                                    @Valid @RequestBody DeleteEquipmentGymRequest request) {
         authorityCheckService.validateByAuthorityId(authentication, authorityId);
-        equipmentGymService.deleteEquipmentGym(request.getEquipmentGymId());
+        equipmentGymService.deactivateEquipmentGym(request.getEquipmentGymId());
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/com/newfit/reservation/domains/authority/controller/ManagerApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/controller/ManagerApiController.java
@@ -79,11 +79,11 @@ public class ManagerApiController {
     cascade 설정에 따라 연관된 EquipmentGym도 삭제
      */
     @DeleteMapping("/equipments")
-    public ResponseEntity<Void> deleteEquipment( Authentication authentication,
+    public ResponseEntity<Void> deactivateEquipment( Authentication authentication,
                                                  @RequestHeader("authority-id") Long authorityId,
                                                  @Valid @RequestBody DeleteEquipmentRequest request) {
         authorityCheckService.validateByAuthorityId(authentication, authorityId);
-        equipmentService.deleteEquipment(request.getEquipmentId());
+        equipmentService.deactivateEquipment(request.getEquipmentId());
         return ResponseEntity
                 .noContent()
                 .build();

--- a/src/main/java/com/newfit/reservation/domains/authority/domain/Authority.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/domain/Authority.java
@@ -53,10 +53,10 @@ public class Authority extends BaseTimeEntity {
     private LocalDateTime tagAt;
 
     // 양방향 연관관계를 나타냅니다.
-    @OneToMany(mappedBy = "authority", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "authority", cascade = CascadeType.REMOVE)
     private List<Credit> creditList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "authority", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "authority")
     private List<Reservation> reservationList = new ArrayList<>();
 
     // accepted 필드값을 true로 업데이트하는 메소드입니다.

--- a/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
@@ -16,6 +16,7 @@ import com.newfit.reservation.domains.gym.repository.GymRepository;
 import com.newfit.reservation.domains.reservation.domain.Reservation;
 import com.newfit.reservation.domains.reservation.repository.ReservationRepository;
 import com.newfit.reservation.domains.routine.domain.Routine;
+import com.newfit.reservation.domains.routine.repository.EquipmentRoutineRepository;
 import com.newfit.reservation.domains.routine.repository.RoutineRepository;
 import com.newfit.reservation.domains.user.domain.User;
 import com.newfit.reservation.domains.user.repository.UserRepository;
@@ -43,6 +44,7 @@ public class AuthorityService {
     private final TokenProvider tokenProvider;
     private final EquipmentGymRepository equipmentGymRepository;
     private final RoutineRepository routineRepository;
+    private final EquipmentRoutineRepository equipmentRoutineRepository;
 
     public void register(Long userId, Long gymId, HttpServletResponse response) {
 
@@ -57,7 +59,8 @@ public class AuthorityService {
     }
 
     public void delete(Long authorityId, HttpServletResponse response) {
-        Authority authority = authorityRepository.findById(authorityId).orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
+        Authority authority = authorityRepository.findById(authorityId)
+                .orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
         User user = authority.getUser();
         user.getAuthorityList().remove(authority);
 
@@ -79,7 +82,10 @@ public class AuthorityService {
 
     private void deleteRelatedRoutines(Authority authority) {
         List<Routine> routines = routineRepository.findAllByAuthority(authority);
-        routineRepository.deleteAll(routines);
+        routines.forEach(routine -> {
+            equipmentRoutineRepository.deleteAllByRoutine(routine);
+            routineRepository.delete(routine);
+        });
     }
 
     public GymListResponse listRegistration(Long authorityId) {

--- a/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
@@ -13,7 +13,10 @@ import com.newfit.reservation.domains.equipment.domain.EquipmentGym;
 import com.newfit.reservation.domains.equipment.repository.EquipmentGymRepository;
 import com.newfit.reservation.domains.gym.domain.Gym;
 import com.newfit.reservation.domains.gym.repository.GymRepository;
+import com.newfit.reservation.domains.reservation.domain.Reservation;
 import com.newfit.reservation.domains.reservation.repository.ReservationRepository;
+import com.newfit.reservation.domains.routine.domain.Routine;
+import com.newfit.reservation.domains.routine.repository.RoutineRepository;
 import com.newfit.reservation.domains.user.domain.User;
 import com.newfit.reservation.domains.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
@@ -39,6 +42,7 @@ public class AuthorityService {
     private final ReservationRepository reservationRepository;
     private final TokenProvider tokenProvider;
     private final EquipmentGymRepository equipmentGymRepository;
+    private final RoutineRepository routineRepository;
 
     public void register(Long userId, Long gymId, HttpServletResponse response) {
 
@@ -55,13 +59,27 @@ public class AuthorityService {
     public void delete(Long authorityId, HttpServletResponse response) {
         Authority authority = authorityRepository.findById(authorityId).orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
         User user = authority.getUser();
-
         user.getAuthorityList().remove(authority);
+
+        deleteRelatedRoutines(authority);
+        deleteRelationWithReservation(authorityId);
+
         authorityRepository.delete(authority);
 
         String accessToken = tokenProvider.generateAccessToken(user);
         log.info("AuthorityDelete.accessToken = {}", accessToken);
         response.setHeader("access-token", accessToken);
+    }
+
+    private void deleteRelationWithReservation(Long authorityId) {
+        List<Reservation> reservations = reservationRepository.findAllByAuthorityId(authorityId);
+        reservations.forEach(Reservation::removeAuthority);
+        reservationRepository.saveAllAndFlush(reservations);
+    }
+
+    private void deleteRelatedRoutines(Authority authority) {
+        List<Routine> routines = routineRepository.findAllByAuthority(authority);
+        routineRepository.deleteAll(routines);
     }
 
     public GymListResponse listRegistration(Long authorityId) {

--- a/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
@@ -74,18 +74,18 @@ public class AuthorityService {
         response.setHeader("access-token", accessToken);
     }
 
-    private void deleteRelationWithReservation(Long authorityId) {
-        List<Reservation> reservations = reservationRepository.findAllByAuthorityId(authorityId);
-        reservations.forEach(Reservation::removeAuthority);
-        reservationRepository.saveAllAndFlush(reservations);
-    }
-
     private void deleteRelatedRoutines(Authority authority) {
         List<Routine> routines = routineRepository.findAllByAuthority(authority);
         routines.forEach(routine -> {
             equipmentRoutineRepository.deleteAllByRoutine(routine);
             routineRepository.delete(routine);
         });
+    }
+
+    private void deleteRelationWithReservation(Long authorityId) {
+        List<Reservation> reservations = reservationRepository.findAllByAuthorityId(authorityId);
+        reservations.forEach(Reservation::removeAuthority);
+        reservationRepository.saveAllAndFlush(reservations);
     }
 
     public GymListResponse listRegistration(Long authorityId) {

--- a/src/main/java/com/newfit/reservation/domains/dev/domain/Proposal.java
+++ b/src/main/java/com/newfit/reservation/domains/dev/domain/Proposal.java
@@ -42,6 +42,10 @@ public class Proposal {
                 .build();
     }
 
+    public void removeUser() {
+        this.user = null;
+    }
+
     // 연관관계 편의 메소드입니다.
     public void setUserRelation(User user) {
         this.user = user;

--- a/src/main/java/com/newfit/reservation/domains/dev/domain/Report.java
+++ b/src/main/java/com/newfit/reservation/domains/dev/domain/Report.java
@@ -42,6 +42,10 @@ public class Report {
                 .build();
     }
 
+    public void removeUser() {
+        this.user = null;
+    }
+
     // 연관관계 편의 메소드입니다.
     public void setUserRelation(User user) {
         this.user = user;

--- a/src/main/java/com/newfit/reservation/domains/dev/repository/ProposalRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/dev/repository/ProposalRepository.java
@@ -1,7 +1,11 @@
 package com.newfit.reservation.domains.dev.repository;
 
 import com.newfit.reservation.domains.dev.domain.Proposal;
+import com.newfit.reservation.domains.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+
+    List<Proposal> findAllByUser(User user);
 }

--- a/src/main/java/com/newfit/reservation/domains/dev/repository/ReportRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/dev/repository/ReportRepository.java
@@ -1,7 +1,11 @@
 package com.newfit.reservation.domains.dev.repository;
 
 import com.newfit.reservation.domains.dev.domain.Report;
+import com.newfit.reservation.domains.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    List<Report> findAllByUser(User user);
 }

--- a/src/main/java/com/newfit/reservation/domains/equipment/domain/Equipment.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/domain/Equipment.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,6 +30,9 @@ public class Equipment extends BaseTimeEntity {
     @Column(nullable = false)
     private PurposeType purposeType;
 
+    @Column(nullable = false)
+    private Boolean deactivated;
+
     @OneToMany(mappedBy = "equipment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<EquipmentGym> equipmentGyms = new ArrayList<>();
 
@@ -39,6 +41,7 @@ public class Equipment extends BaseTimeEntity {
         this.gym = gym;
         this.name = name;
         this.purposeType = purposeType;
+        this.deactivated = false;
     }
 
     public static Equipment createEquipment(Gym gym, String name, PurposeType purposeType) {
@@ -47,5 +50,9 @@ public class Equipment extends BaseTimeEntity {
                 .name(name)
                 .purposeType(purposeType)
                 .build();
+    }
+
+    public void deactivate() {
+        this.deactivated = true;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/equipment/domain/Equipment.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/domain/Equipment.java
@@ -31,7 +31,7 @@ public class Equipment extends BaseTimeEntity {
     private PurposeType purposeType;
 
     @Column(nullable = false)
-    private Boolean deactivated;
+    private Boolean active;
 
     @OneToMany(mappedBy = "equipment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<EquipmentGym> equipmentGyms = new ArrayList<>();
@@ -41,7 +41,7 @@ public class Equipment extends BaseTimeEntity {
         this.gym = gym;
         this.name = name;
         this.purposeType = purposeType;
-        this.deactivated = false;
+        this.active = true;
     }
 
     public static Equipment createEquipment(Gym gym, String name, PurposeType purposeType) {
@@ -53,6 +53,6 @@ public class Equipment extends BaseTimeEntity {
     }
 
     public void deactivate() {
-        this.deactivated = true;
+        this.active = false;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/equipment/domain/Equipment.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/domain/Equipment.java
@@ -33,7 +33,7 @@ public class Equipment extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean active;
 
-    @OneToMany(mappedBy = "equipment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "equipment")
     private List<EquipmentGym> equipmentGyms = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/newfit/reservation/domains/equipment/domain/EquipmentGym.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/domain/EquipmentGym.java
@@ -33,7 +33,7 @@ public class EquipmentGym extends BaseTimeEntity {
     private String name;
 
     @Column(nullable = false)
-    private Boolean deactivated;
+    private Boolean active;
 
     @Builder(access = AccessLevel.PRIVATE)
     private EquipmentGym(Equipment equipment, Gym gym, String name) {
@@ -41,7 +41,7 @@ public class EquipmentGym extends BaseTimeEntity {
         this.gym = gym;
         this.conditionType = ConditionType.AVAILABLE;
         this.name = name;
-        this.deactivated = false;
+        this.active = true;
     }
 
     public static EquipmentGym createEquipmentGym(Equipment equipment, Gym gym, String name) {
@@ -65,6 +65,6 @@ public class EquipmentGym extends BaseTimeEntity {
     }
 
     public void deactivate() {
-        this.deactivated = true;
+        this.active = false;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/equipment/domain/EquipmentGym.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/domain/EquipmentGym.java
@@ -32,12 +32,16 @@ public class EquipmentGym extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
+    private Boolean deactivated;
+
     @Builder(access = AccessLevel.PRIVATE)
     private EquipmentGym(Equipment equipment, Gym gym, String name) {
         this.equipment = equipment;
         this.gym = gym;
         this.conditionType = ConditionType.AVAILABLE;
         this.name = name;
+        this.deactivated = false;
     }
 
     public static EquipmentGym createEquipmentGym(Equipment equipment, Gym gym, String name) {
@@ -58,5 +62,9 @@ public class EquipmentGym extends BaseTimeEntity {
 
     public void restore() {
         this.conditionType = ConditionType.AVAILABLE;
+    }
+
+    public void deactivate() {
+        this.deactivated = true;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentGymService.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentGymService.java
@@ -60,7 +60,7 @@ public class EquipmentGymService {
     /*
     equipmentGym 삭제
      */
-    public void deleteEquipmentGym(Long equipmentGymId) {
+    public void deactivateEquipmentGym(Long equipmentGymId) {
         EquipmentGym equipmentGym = findOneById(equipmentGymId);
         equipmentGym.deactivate();
     }

--- a/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentGymService.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentGymService.java
@@ -61,7 +61,8 @@ public class EquipmentGymService {
     equipmentGym 삭제
      */
     public void deleteEquipmentGym(Long equipmentGymId) {
-        equipmentGymRepository.deleteById(equipmentGymId);
+        EquipmentGym equipmentGym = findOneById(equipmentGymId);
+        equipmentGym.deactivate();
     }
 
     public EquipmentGymListResponse findAllInGymByPurpose(Gym gym, PurposeType purposeType) {

--- a/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentService.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentService.java
@@ -2,12 +2,18 @@ package com.newfit.reservation.domains.equipment.service;
 
 import com.newfit.reservation.common.exception.CustomException;
 import com.newfit.reservation.domains.equipment.domain.Equipment;
+import com.newfit.reservation.domains.equipment.domain.EquipmentGym;
 import com.newfit.reservation.domains.equipment.domain.PurposeType;
+import com.newfit.reservation.domains.equipment.repository.EquipmentGymRepository;
 import com.newfit.reservation.domains.equipment.repository.EquipmentRepository;
 import com.newfit.reservation.domains.gym.domain.Gym;
+import com.newfit.reservation.domains.routine.domain.EquipmentRoutine;
+import com.newfit.reservation.domains.routine.repository.EquipmentRoutineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.newfit.reservation.common.exception.ErrorCodeType.*;
 
@@ -15,7 +21,10 @@ import static com.newfit.reservation.common.exception.ErrorCodeType.*;
 @RequiredArgsConstructor
 @Transactional
 public class EquipmentService {
+
     private final EquipmentRepository equipmentRepository;
+    private final EquipmentGymRepository equipmentGymRepository;
+    private final EquipmentRoutineRepository equipmentRoutineRepository;
 
     /*
     Equipment를 새로 등록.
@@ -36,7 +45,14 @@ public class EquipmentService {
     equipment 삭제
      */
     public void deleteEquipment(Long equipmentId) {
-        equipmentRepository.deleteById(equipmentId);
+        Equipment equipment = findById(equipmentId);
+        equipment.deactivate();
+
+        List<EquipmentGym> equipmentGyms = equipmentGymRepository.findAllByEquipment_Id(equipmentId);
+        equipmentGyms.forEach(EquipmentGym::deactivate);
+
+        List<EquipmentRoutine> equipmentRoutines = equipmentRoutineRepository.findAllByEquipment_Id(equipmentId);
+        equipmentRoutines.forEach(EquipmentRoutine::deactivate);
     }
 
     /*

--- a/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentService.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentService.java
@@ -4,7 +4,6 @@ import com.newfit.reservation.common.exception.CustomException;
 import com.newfit.reservation.domains.equipment.domain.Equipment;
 import com.newfit.reservation.domains.equipment.domain.EquipmentGym;
 import com.newfit.reservation.domains.equipment.domain.PurposeType;
-import com.newfit.reservation.domains.equipment.repository.EquipmentGymRepository;
 import com.newfit.reservation.domains.equipment.repository.EquipmentRepository;
 import com.newfit.reservation.domains.gym.domain.Gym;
 import com.newfit.reservation.domains.routine.domain.EquipmentRoutine;
@@ -12,7 +11,6 @@ import com.newfit.reservation.domains.routine.repository.EquipmentRoutineReposit
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 
 import static com.newfit.reservation.common.exception.ErrorCodeType.*;
@@ -23,7 +21,6 @@ import static com.newfit.reservation.common.exception.ErrorCodeType.*;
 public class EquipmentService {
 
     private final EquipmentRepository equipmentRepository;
-    private final EquipmentGymRepository equipmentGymRepository;
     private final EquipmentRoutineRepository equipmentRoutineRepository;
 
     /*
@@ -48,7 +45,7 @@ public class EquipmentService {
         Equipment equipment = findById(equipmentId);
         equipment.deactivate();
 
-        List<EquipmentGym> equipmentGyms = equipmentGymRepository.findAllByEquipment_Id(equipmentId);
+        List<EquipmentGym> equipmentGyms = equipment.getEquipmentGyms();
         equipmentGyms.forEach(EquipmentGym::deactivate);
 
         List<EquipmentRoutine> equipmentRoutines = equipmentRoutineRepository.findAllByEquipment_Id(equipmentId);

--- a/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentService.java
+++ b/src/main/java/com/newfit/reservation/domains/equipment/service/EquipmentService.java
@@ -44,7 +44,7 @@ public class EquipmentService {
     /*
     equipment 삭제
      */
-    public void deleteEquipment(Long equipmentId) {
+    public void deactivateEquipment(Long equipmentId) {
         Equipment equipment = findById(equipmentId);
         equipment.deactivate();
 

--- a/src/main/java/com/newfit/reservation/domains/reservation/domain/Reservation.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/domain/Reservation.java
@@ -57,6 +57,9 @@ public class Reservation extends BaseTimeEntity {
         this.startTagAt = null;
     }
 
+    public void removeAuthority() {
+        this.authority = null;
+    }
 
     public void updateEquipmentGym(EquipmentGym equipmentGym) {
         this.equipmentGym = equipmentGym;

--- a/src/main/java/com/newfit/reservation/domains/reservation/domain/Reservation.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/domain/Reservation.java
@@ -23,7 +23,7 @@ public class Reservation extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "authority_id", nullable = false)
+    @JoinColumn(name = "authority_id")
     private Authority authority;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/newfit/reservation/domains/routine/domain/EquipmentRoutine.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/domain/EquipmentRoutine.java
@@ -32,7 +32,7 @@ public class EquipmentRoutine {
     private Short sequence;
 
     @Column(nullable = false)
-    private Boolean deactivated;
+    private Boolean active;
 
     @Builder(access = AccessLevel.PRIVATE)
     private EquipmentRoutine(Equipment equipment, Routine routine, Duration duration, Short sequence) {
@@ -40,7 +40,7 @@ public class EquipmentRoutine {
         this.routine = routine;
         this.duration = duration;
         this.sequence = sequence;
-        this.deactivated = false;
+        this.active = true;
     }
 
     public static EquipmentRoutine createEquipmentRoutine(Equipment equipment, Routine routine,
@@ -66,6 +66,6 @@ public class EquipmentRoutine {
     }
 
     public void deactivate() {
-        this.deactivated = true;
+        this.active = false;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/routine/domain/EquipmentRoutine.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/domain/EquipmentRoutine.java
@@ -1,13 +1,11 @@
 package com.newfit.reservation.domains.routine.domain;
 
-
 import com.newfit.reservation.domains.equipment.domain.Equipment;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.Duration;
 
 @Getter
@@ -33,12 +31,16 @@ public class EquipmentRoutine {
     @Column(nullable = false)
     private Short sequence;
 
+    @Column(nullable = false)
+    private Boolean deactivated;
+
     @Builder(access = AccessLevel.PRIVATE)
     private EquipmentRoutine(Equipment equipment, Routine routine, Duration duration, Short sequence) {
         this.equipment = equipment;
         this.routine = routine;
         this.duration = duration;
         this.sequence = sequence;
+        this.deactivated = false;
     }
 
     public static EquipmentRoutine createEquipmentRoutine(Equipment equipment, Routine routine,
@@ -61,5 +63,9 @@ public class EquipmentRoutine {
         if (duration != null) {
             this.duration = duration;
         }
+    }
+
+    public void deactivate() {
+        this.deactivated = true;
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/routine/repository/EquipmentRoutineRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/repository/EquipmentRoutineRepository.java
@@ -19,4 +19,6 @@ public interface EquipmentRoutineRepository extends JpaRepository<EquipmentRouti
 
     // sequence로 정렬된 Routine의 모든 EquipmentRoutine 객체를 조회
     List<EquipmentRoutine> findAllByRoutineIdOrderBySequence(Long routineId);
+
+    List<EquipmentRoutine> findAllByEquipment_Id(Long equipmentId);
 }

--- a/src/main/java/com/newfit/reservation/domains/user/domain/User.java
+++ b/src/main/java/com/newfit/reservation/domains/user/domain/User.java
@@ -61,7 +61,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "file_path", nullable = false)
     private String filePath;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", cascade = CascadeType.REMOVE)
     private OAuthHistory oAuthHistory;
 
     // 양방향 연관관계를 나타냅니다.
@@ -73,7 +73,7 @@ public class User extends BaseTimeEntity {
     private List<Proposal> proposalList = new ArrayList<>();
 
     // 양방향 연관관계를 나타냅니다.
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
     private List<Authority> authorityList = new ArrayList<>();
 
     /* =========== update method  =========== */

--- a/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
@@ -16,6 +16,7 @@ import com.newfit.reservation.domains.dev.repository.ReportRepository;
 import com.newfit.reservation.domains.reservation.domain.Reservation;
 import com.newfit.reservation.domains.reservation.repository.ReservationRepository;
 import com.newfit.reservation.domains.routine.domain.Routine;
+import com.newfit.reservation.domains.routine.repository.EquipmentRoutineRepository;
 import com.newfit.reservation.domains.routine.repository.RoutineRepository;
 import com.newfit.reservation.domains.user.domain.User;
 import com.newfit.reservation.domains.user.dto.request.UserSignUpRequest;
@@ -50,6 +51,7 @@ public class UserService {
     private final ReportRepository reportRepository;
     private final ProposalRepository proposalRepository;
     private final RoutineRepository routineRepository;
+    private final EquipmentRoutineRepository equipmentRoutineRepository;
     private final ReservationRepository reservationRepository;
 
     public void modify(Long userId, UserUpdateRequest request, HttpServletResponse response) {
@@ -146,7 +148,10 @@ public class UserService {
 
     private void deleteRelatedRoutines(Authority authority) {
         List<Routine> routines = routineRepository.findAllByAuthority(authority);
-        routineRepository.deleteAll(routines);
+        routines.forEach(routine -> {
+            equipmentRoutineRepository.deleteAllByRoutine(routine);
+            routineRepository.delete(routine);
+        });
     }
 
     public User findOneById(Long userId) {


### PR DESCRIPTION
## 개요
- close #178 

## 작업사항
- User 삭제 -> Authority , OAuthHistory, RefreshToken 삭제 (+ Report, Proposal에서는 User 필드를 null로 변경)
- Authority 삭제 -> Credit, Routine 삭제, Reservation의 authorityId는 null로 변경
- Routine 삭제 -> EquipmentRoutine 삭제
- Equipment 비활성화 -> EquipmentRoutine, EquipmentGym 비활성화
- EquipmentGym 비활성화 기능 추가