### PR TITLE
refactor: Routine에 EquipmentRoutine과의 양방향 연관 관계 설정 및 cascade 적용 (#250)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/service/AuthorityService.java
@@ -59,8 +59,7 @@ public class AuthorityService {
     }
 
     public void delete(Long authorityId, HttpServletResponse response) {
-        Authority authority = authorityRepository.findById(authorityId)
-                .orElseThrow(() -> new CustomException(AUTHORITY_NOT_FOUND));
+        Authority authority = findById(authorityId);
         User user = authority.getUser();
         user.getAuthorityList().remove(authority);
 
@@ -76,10 +75,7 @@ public class AuthorityService {
 
     private void deleteRelatedRoutines(Authority authority) {
         List<Routine> routines = routineRepository.findAllByAuthority(authority);
-        routines.forEach(routine -> {
-            equipmentRoutineRepository.deleteAllByRoutine(routine);
-            routineRepository.delete(routine);
-        });
+        routineRepository.deleteAll(routines);
     }
 
     private void deleteRelationWithReservation(Long authorityId) {

--- a/src/main/java/com/newfit/reservation/domains/routine/domain/Routine.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/domain/Routine.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -24,7 +26,11 @@ public class Routine extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
-    private Long count = 0L;
+    @Column(nullable = false)
+    private Long count;
+
+    @OneToMany(mappedBy = "routine", cascade = CascadeType.REMOVE)
+    private List<EquipmentRoutine> equipmentRoutineList = new ArrayList<>();
 
     public void updateName(String name) {
         this.name = name;
@@ -38,6 +44,7 @@ public class Routine extends BaseTimeEntity {
     private Routine(Authority authority, String name) {
         this.authority = authority;
         this.name = name;
+        this.count = 0L;
     }
 
     public static Routine createRoutine(Authority authority, String name) {

--- a/src/main/java/com/newfit/reservation/domains/routine/repository/EquipmentRoutineRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/repository/EquipmentRoutineRepository.java
@@ -8,9 +8,6 @@ import java.util.Optional;
 
 public interface EquipmentRoutineRepository extends JpaRepository<EquipmentRoutine, Long> {
 
-    // Routine의 모든 EquipmentRoutine 객체를 삭제
-    void deleteAllByRoutine(Routine routine);
-
     // Routine의 모든 EquipmentRoutine 객체를 조회
     List<EquipmentRoutine> findAllByRoutine(Routine routine);
 

--- a/src/main/java/com/newfit/reservation/domains/routine/service/RoutineService.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/service/RoutineService.java
@@ -73,8 +73,8 @@ public class RoutineService {
     특정 Routine 객체를 삭제하는 경우 해당 Routine에 묶여있는 EquipmentRoutine 객체들도 모두 삭제합니다.
      */
     public void deleteRoutine(Long routineId) {
-        Routine findRoutine = findById(routineId);
-        routineRepository.delete(findRoutine);
+        Routine routine = findById(routineId);
+        routineRepository.delete(routine);
     }
 
     /*

--- a/src/main/java/com/newfit/reservation/domains/routine/service/RoutineService.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/service/RoutineService.java
@@ -1,6 +1,5 @@
 package com.newfit.reservation.domains.routine.service;
 
-
 import com.newfit.reservation.common.exception.CustomException;
 import com.newfit.reservation.domains.authority.domain.Authority;
 import com.newfit.reservation.domains.authority.repository.AuthorityRepository;
@@ -75,8 +74,7 @@ public class RoutineService {
      */
     public void deleteRoutine(Long routineId) {
         Routine findRoutine = findById(routineId);
-        equipmentRoutineRepository.deleteAllByRoutine(findRoutine);
-        routineRepository.deleteById(routineId);
+        routineRepository.delete(findRoutine);
     }
 
     /*

--- a/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
+++ b/src/main/java/com/newfit/reservation/domains/user/service/UserService.java
@@ -148,10 +148,7 @@ public class UserService {
 
     private void deleteRelatedRoutines(Authority authority) {
         List<Routine> routines = routineRepository.findAllByAuthority(authority);
-        routines.forEach(routine -> {
-            equipmentRoutineRepository.deleteAllByRoutine(routine);
-            routineRepository.delete(routine);
-        });
+        routineRepository.deleteAll(routines);
     }
 
     public User findOneById(Long userId) {


### PR DESCRIPTION
## 개요
- close #250 

## 작업사항
- Routine에 EquipmentRoutine 리스트 추가
- RoutineService deleteRoutine 메소드 내부 로직 수정
- AuthorityService deleteRelatedRoutines 내부 로직 수정
- UserService deleteRelatedRoutines 내부 로직 수정