### PR TITLE
refactor: 헬스장 전체 조회 시 response에 헬스장 id도 포함하도록 수정 (#263)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/authority/dto/response/GymResponse.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/dto/response/GymResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.newfit.reservation.domains.authority.domain.Authority;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +15,6 @@ public class GymResponse {
     private String gymName;
     private String address;
 
-    @Builder
     private GymResponse(Long gymId, String gymName, String address) {
         this.gymId = gymId;
         this.gymName = gymName;

--- a/src/main/java/com/newfit/reservation/domains/authority/dto/response/GymResponse.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/dto/response/GymResponse.java
@@ -3,7 +3,6 @@ package com.newfit.reservation.domains.authority.dto.response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.newfit.reservation.domains.authority.domain.Authority;
-import com.newfit.reservation.domains.gym.domain.Gym;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,19 +12,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GymResponse {
+    private Long gymId;
     private String gymName;
     private String address;
 
     @Builder
-    private GymResponse(String gymName, String address) {
+    private GymResponse(Long gymId, String gymName, String address) {
+        this.gymId = gymId;
         this.gymName = gymName;
         this.address = address;
     }
 
     public GymResponse(Authority authority) {
-        this(authority.getGym().getName(), authority.getGym().getAddress());
+        this(authority.getGym().getId(), authority.getGym().getName(), authority.getGym().getAddress());
     }
-
-    // Gym 객체로부터 GymResponseDto를 생성합니다.
-    public GymResponse(Gym gym) { this(gym.getName(), gym.getAddress()); }
 }

--- a/src/main/java/com/newfit/reservation/domains/gym/dto/response/GymResponse.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/dto/response/GymResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.newfit.reservation.domains.gym.domain.Gym;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +15,6 @@ public class GymResponse {
     private String gymName;
     private String address;
 
-    @Builder(access = AccessLevel.PRIVATE)
     private GymResponse(Long gymId, String gymName, String address) {
         this.gymId = gymId;
         this.gymName = gymName;

--- a/src/main/java/com/newfit/reservation/domains/gym/dto/response/GymResponse.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/dto/response/GymResponse.java
@@ -2,7 +2,6 @@ package com.newfit.reservation.domains.gym.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.newfit.reservation.domains.authority.domain.Authority;
 import com.newfit.reservation.domains.gym.domain.Gym;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,21 +12,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GymResponse {
+    private Long gymId;
     private String gymName;
     private String address;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private GymResponse(String gymName, String address) {
+    private GymResponse(Long gymId, String gymName, String address) {
+        this.gymId = gymId;
         this.gymName = gymName;
         this.address = address;
     }
 
-    public GymResponse(Authority authority) {
-        this(authority.getGym().getName(), authority.getGym().getAddress());
-    }
-
     // Gym 객체로부터 GymResponseDto를 생성합니다.
     public GymResponse(Gym gym) {
-        this(gym.getName(), gym.getAddress());
+        this(gym.getId(), gym.getName(), gym.getAddress());
     }
 }


### PR DESCRIPTION
## 개요
- close #263 
## 작업사항
- gym 패키지 소속 GymResponse에 gymId 필드 추가
- authority 패키지 소속 GymResponse에 gymId 필드 추가