### PR TITLE
refactor: Gym 조회 시 대소문자 구분하지 않고 조회할 수 있도록 수정 (#267)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface GymRepository extends JpaRepository<Gym, Long> {
-    @Query(value = "select * from gym where name ~ :keywordString", nativeQuery = true)
+    @Query(value = "select * from gym where name ~* :keywordString", nativeQuery = true)
     List<Gym> findAllByNameContaining(@Param("keywordString") String keywordString);
 }

--- a/src/test/java/com/newfit/reservation/domains/gym/repository/GymRepositoryTest.java
+++ b/src/test/java/com/newfit/reservation/domains/gym/repository/GymRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.newfit.reservation.domains.gym.repository;
+
+import com.newfit.reservation.domains.gym.domain.Gym;
+import com.newfit.reservation.domains.gym.dto.request.admin.CreateGymRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class GymRepositoryTest {
+
+    @Autowired
+    private GymRepository gymRepository;
+
+    @Test
+    @DisplayName("영어로 된 헬스장 이름 조회 시 대소문자를 구분하지 않고 조회해야 한다.")
+    void caseInsensitiveSearchTest() {
+        // given
+        CreateGymRequest request = new CreateGymRequest();
+        request.setName("Sad Gym");
+        request.setTel("010-1235-4565");
+        request.setAddress("마포구 와우산로");
+        request.setOpenAt(LocalTime.MIN);
+        request.setCloseAt(LocalTime.MAX);
+        request.setAllDay(false);
+
+        Gym gym = Gym.from(request);
+        gymRepository.save(gym);
+
+        // when
+        List<Gym> gyms = gymRepository.findAllByNameContaining("(sad|gym)");
+
+        // then
+        assertThat(gyms.size()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## 개요
- close #267 
## 작업사항
- GymRepository 내부 조회 쿼리 수정
- 해당 조회 로직 테스트 코드 작성(DataJpaTest 사용) 
