### PR TITLE
refactor: AuthorityRepository의 @Query문을 querydsl로 변경 (#272)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepository.java
@@ -1,26 +1,10 @@
 package com.newfit.reservation.domains.authority.repository;
 
 import com.newfit.reservation.domains.authority.domain.Authority;
-import com.newfit.reservation.domains.authority.domain.RoleType;
 import com.newfit.reservation.domains.gym.domain.Gym;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import java.util.List;
-import java.util.Optional;
 
-public interface AuthorityRepository extends JpaRepository<Authority, Long> {
+public interface AuthorityRepository extends JpaRepository<Authority, Long>, AuthorityRepositoryCustom {
     List<Authority> findAllAuthorityByGym(Gym gym);
-
-    @Query("SELECT a FROM Authority a WHERE a.user.id = :userId")
-    List<Authority> findAllAuthorityByUserId(@Param("userId") Long id);
-
-    @Query("SELECT a from Authority a where a.user.id =:userId and a.gym.id =:gymId and a.roleType =:roleType")
-    Authority findOneByUserIdAndGymIdAndRoleType(@Param("userId") Long userId, @Param("gymId") Long gymId, @Param("roleType") RoleType roleType);
-
-    @Query("select a from Authority a where a.creditAcquisitionCount <> 0")
-    List<Authority> findAllByCreditAcquisitionCountNotZero();
-
-    @Query("SELECT a from Authority a where a.user.nickname =:nickname and a.gym.id =:gymId")
-    Optional<Authority> findOneByUserNicknameAndGymId(@Param("nickname") String nickname, @Param("gymId") Long gymId);
 }

--- a/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryCustom.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.newfit.reservation.domains.authority.repository;
+
+import com.newfit.reservation.domains.authority.domain.Authority;
+import com.newfit.reservation.domains.authority.domain.RoleType;
+import java.util.List;
+import java.util.Optional;
+
+public interface AuthorityRepositoryCustom {
+
+    List<Authority> findAllAuthorityByUserId(Long id);
+
+    Authority findOneByUserIdAndGymIdAndRoleType(Long userId, Long gymId, RoleType roleType);
+
+    List<Authority> findAllByCreditAcquisitionCountNotZero();
+
+    Optional<Authority> findOneByUserNicknameAndGymId(String nickname, Long gymId);
+}

--- a/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryImpl.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryImpl.java
@@ -15,10 +15,10 @@ public class AuthorityRepositoryImpl implements AuthorityRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Authority> findAllAuthorityByUserId(Long id) {
+    public List<Authority> findAllAuthorityByUserId(Long userId) {
         return queryFactory
                 .selectFrom(authority)
-                .where(authority.id.eq(id))
+                .where(authority.user.id.eq(userId))
                 .fetch();
     }
 

--- a/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryImpl.java
+++ b/src/main/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.newfit.reservation.domains.authority.repository;
+
+import com.newfit.reservation.domains.authority.domain.Authority;
+import com.newfit.reservation.domains.authority.domain.RoleType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Optional;
+
+import static com.newfit.reservation.domains.authority.domain.QAuthority.*;
+
+@RequiredArgsConstructor
+public class AuthorityRepositoryImpl implements AuthorityRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Authority> findAllAuthorityByUserId(Long id) {
+        return queryFactory
+                .selectFrom(authority)
+                .where(authority.id.eq(id))
+                .fetch();
+    }
+
+    @Override
+    public Authority findOneByUserIdAndGymIdAndRoleType(Long userId, Long gymId, RoleType roleType) {
+        return queryFactory
+                .selectFrom(authority)
+                .where(authority.user.id.eq(userId)
+                        .and(authority.gym.id.eq(gymId))
+                        .and(authority.roleType.eq(roleType)))
+                .fetchOne();
+
+    }
+
+    @Override
+    public List<Authority> findAllByCreditAcquisitionCountNotZero() {
+        return queryFactory
+                .selectFrom(authority)
+                .where(authority.creditAcquisitionCount.eq((short) 0).not())
+                .fetch();
+    }
+
+    @Override
+    public Optional<Authority> findOneByUserNicknameAndGymId(String nickname, Long gymId) {
+        return Optional.ofNullable(
+                queryFactory
+                    .selectFrom(authority)
+                    .where(authority.user.nickname.eq(nickname)
+                            .and(authority.gym.id.eq(gymId)))
+                    .fetchOne()
+                );
+    }
+}

--- a/src/test/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryTest.java
+++ b/src/test/java/com/newfit/reservation/domains/authority/repository/AuthorityRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.newfit.reservation.domains.authority.repository;
+
+import com.newfit.reservation.common.config.QuerydslConfig;
+import com.newfit.reservation.domains.authority.domain.Authority;
+import com.newfit.reservation.domains.authority.domain.RoleType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AuthorityRepositoryTest {
+
+    @Autowired
+    private AuthorityRepository authorityRepository;
+
+    @Test
+    void userId로_authority_모두_조회() {
+        // given
+        Long userId = 1L;
+
+        // when
+        List<Authority> result = authorityRepository.findAllAuthorityByUserId(userId);
+
+        // then
+        for (Authority authority : result) {
+            assertThat(authority.getUser().getId()).isEqualTo(userId);
+        }
+    }
+
+    @Test
+    void userId_GymId_RoleType_으로_하나_조회() {
+        // given
+        Long userId = 1L;
+        Long gymId = 1L;
+        RoleType roleType = RoleType.ADMIN;
+
+        // when
+        Authority result = authorityRepository.findOneByUserIdAndGymIdAndRoleType(userId, gymId, roleType);
+
+        // then
+        assertThat(result.getUser().getId()).isEqualTo(userId);
+        assertThat(result.getGym().getId()).isEqualTo(gymId);
+        assertThat(result.getRoleType()).isEqualTo(roleType);
+    }
+
+    @Test
+    void creditAcquisition이_모두_0이_아닌지_확인() {
+        // when
+        List<Authority> authorityList = authorityRepository.findAllByCreditAcquisitionCountNotZero();
+
+        // then
+        for (Authority authority : authorityList) {
+            assertThat(authority.getCreditAcquisitionCount()).isNotEqualTo(0);
+        }
+    }
+
+    @Test
+    void nickname과_gymId로_하나_조회() {
+        // given
+        String nickname = "Sponge Bob";
+        Long gymId = 1L;
+
+        // when
+        Authority result = authorityRepository.findOneByUserNicknameAndGymId(nickname, gymId)
+                .orElse(null);
+
+        // then
+        assertThat(result.getUser().getNickname()).isEqualTo(nickname);
+        assertThat(result.getGym().getId()).isEqualTo(gymId);
+    }
+}


### PR DESCRIPTION
## 개요
- close #272 
## 작업사항
- AuthorityRepository의 @Query문을 querydsl로 변경
- test 작성