### PR TITLE
refactor: GymRepository에 querydsl 적용 (#274)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepository.java
@@ -2,11 +2,6 @@ package com.newfit.reservation.domains.gym.repository;
 
 import com.newfit.reservation.domains.gym.domain.Gym;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import java.util.List;
 
-public interface GymRepository extends JpaRepository<Gym, Long> {
-    @Query(value = "select * from gym where name ~* :keywordString", nativeQuery = true)
-    List<Gym> findAllByNameContaining(@Param("keywordString") String keywordString);
+public interface GymRepository extends JpaRepository<Gym, Long>, GymRepositoryCustom {
 }

--- a/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepositoryCustom.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.newfit.reservation.domains.gym.repository;
+
+import com.newfit.reservation.domains.gym.domain.Gym;
+import java.util.List;
+
+public interface GymRepositoryCustom {
+
+    List<Gym> findAllByNameContaining(List<String> keywordString);
+}

--- a/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepositoryImpl.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepositoryImpl.java
@@ -13,16 +13,16 @@ public class GymRepositoryImpl implements GymRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Gym> findAllByNameContaining(List<String> keywordString) {
+    public List<Gym> findAllByNameContaining(List<String> keywords) {
         return queryFactory
                 .selectFrom(gym)
-                .where(containsKeyword(keywordString))
+                .where(containsKeyword(keywords))
                 .fetch();
     }
 
-    private BooleanBuilder containsKeyword(List<String> keywordString) {
-        return keywordString.stream()
-                .map(string -> gym.name.toLowerCase().contains(string.toLowerCase()))
+    private BooleanBuilder containsKeyword(List<String> keywords) {
+        return keywords.stream()
+                .map(keyword -> gym.name.toLowerCase().contains(keyword.toLowerCase()))
                 .reduce(new BooleanBuilder(), BooleanBuilder::or, BooleanBuilder::or);
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepositoryImpl.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/repository/GymRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.newfit.reservation.domains.gym.repository;
+
+import com.newfit.reservation.domains.gym.domain.Gym;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import static com.newfit.reservation.domains.gym.domain.QGym.*;
+
+@RequiredArgsConstructor
+public class GymRepositoryImpl implements GymRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Gym> findAllByNameContaining(List<String> keywordString) {
+        return queryFactory
+                .selectFrom(gym)
+                .where(containsKeyword(keywordString))
+                .fetch();
+    }
+
+    private BooleanBuilder containsKeyword(List<String> keywordString) {
+        return keywordString.stream()
+                .map(string -> gym.name.toLowerCase().contains(string.toLowerCase()))
+                .reduce(new BooleanBuilder(), BooleanBuilder::or, BooleanBuilder::or);
+    }
+}

--- a/src/main/java/com/newfit/reservation/domains/gym/service/GymService.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/service/GymService.java
@@ -28,6 +28,6 @@ public class GymService {
         if (gymName == null || gymName.trim().equals("헬스장")) {
             return new ArrayList<>();
         }
-        return Arrays.stream(gymName.replace("헬스장", "").trim().split("\s")).toList();
+        return Arrays.stream(gymName.replace("헬스장", "").trim().split("\s+")).toList();
     }
 }

--- a/src/main/java/com/newfit/reservation/domains/gym/service/GymService.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/service/GymService.java
@@ -16,8 +16,8 @@ public class GymService {
     private final GymRepository gymRepository;
 
     public GymListResponse searchGyms(String gymName) {
-        List<String> keywordString = processQueryParam(gymName);
-        List<Gym> findGyms = gymRepository.findAllByNameContaining(keywordString);
+        List<String> keywords = processQueryParam(gymName);
+        List<Gym> findGyms = gymRepository.findAllByNameContaining(keywords);
         List<GymResponse> gyms = findGyms.stream()
                 .map(GymResponse::new).toList();
 

--- a/src/main/java/com/newfit/reservation/domains/gym/service/GymService.java
+++ b/src/main/java/com/newfit/reservation/domains/gym/service/GymService.java
@@ -6,6 +6,8 @@ import com.newfit.reservation.domains.gym.dto.response.GymResponse;
 import com.newfit.reservation.domains.gym.repository.GymRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -14,7 +16,7 @@ public class GymService {
     private final GymRepository gymRepository;
 
     public GymListResponse searchGyms(String gymName) {
-        String keywordString = processQueryParam(gymName);
+        List<String> keywordString = processQueryParam(gymName);
         List<Gym> findGyms = gymRepository.findAllByNameContaining(keywordString);
         List<GymResponse> gyms = findGyms.stream()
                 .map(GymResponse::new).toList();
@@ -22,11 +24,10 @@ public class GymService {
         return GymListResponse.createResponse(gyms);
     }
 
-    private String processQueryParam(String gymName) {
-        if (gymName == null) {
-            return "()";
+    private List<String> processQueryParam(String gymName) {
+        if (gymName == null || gymName.trim().equals("헬스장")) {
+            return new ArrayList<>();
         }
-        String processedGymName = gymName.replace("헬스장", "").trim().replaceAll("\s+", "|");
-        return "(" + processedGymName + ")";
+        return Arrays.stream(gymName.replace("헬스장", "").trim().split("\s")).toList();
     }
 }

--- a/src/test/java/com/newfit/reservation/domains/gym/repository/GymRepositoryTest.java
+++ b/src/test/java/com/newfit/reservation/domains/gym/repository/GymRepositoryTest.java
@@ -49,7 +49,7 @@ class GymRepositoryTest {
     void 헬스장_키워드로_검색() {
         // given
         CreateGymRequest request = new CreateGymRequest();
-        request.setName("Sad Gym");
+        request.setName("Sad but happy Gym");
         request.setTel("010-1235-4565");
         request.setAddress("마포구 와우산로");
         request.setOpenAt(LocalTime.MIN);
@@ -60,9 +60,10 @@ class GymRepositoryTest {
         gymRepository.save(gym);
 
         // when
-        List<Gym> gyms = gymRepository.findAllByNameContaining(Arrays.asList("sAd", "gym"));
+        List<Gym> findBySad = gymRepository.findAllByNameContaining(List.of("Sad"));
+        List<Gym> findByHappy = gymRepository.findAllByNameContaining(List.of("Happy"));
 
         // then
-        assertThat(gyms.size()).isEqualTo(1);
+        assertThat(findBySad.size()).isEqualTo(findByHappy.size());
     }
 }

--- a/src/test/java/com/newfit/reservation/domains/gym/repository/GymRepositoryTest.java
+++ b/src/test/java/com/newfit/reservation/domains/gym/repository/GymRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.newfit.reservation.domains.gym.repository;
 
+import com.newfit.reservation.common.config.QuerydslConfig;
 import com.newfit.reservation.domains.gym.domain.Gym;
 import com.newfit.reservation.domains.gym.dto.request.admin.CreateGymRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -7,12 +8,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import java.time.LocalTime;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
+@Import(QuerydslConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class GymRepositoryTest {
 
@@ -35,7 +39,28 @@ class GymRepositoryTest {
         gymRepository.save(gym);
 
         // when
-        List<Gym> gyms = gymRepository.findAllByNameContaining("(sad|gym)");
+        List<Gym> gyms = gymRepository.findAllByNameContaining(Arrays.asList("sAd", "gym"));
+
+        // then
+        assertThat(gyms.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 헬스장_키워드로_검색() {
+        // given
+        CreateGymRequest request = new CreateGymRequest();
+        request.setName("Sad Gym");
+        request.setTel("010-1235-4565");
+        request.setAddress("마포구 와우산로");
+        request.setOpenAt(LocalTime.MIN);
+        request.setCloseAt(LocalTime.MAX);
+        request.setAllDay(false);
+
+        Gym gym = Gym.from(request);
+        gymRepository.save(gym);
+
+        // when
+        List<Gym> gyms = gymRepository.findAllByNameContaining(Arrays.asList("sAd", "gym"));
 
         // then
         assertThat(gyms.size()).isEqualTo(1);


### PR DESCRIPTION
## 개요
- close #274 
## 작업사항
- GymRepository에 querydsl 적용
- GymService에서 keyword를 처리하여 List를 반환하도록 변경