### PR TITLE
refactor: ReservationRepository에 querydsl 적용 (#274)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepository.java
@@ -10,10 +10,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-
-    @Query("select r from Reservation r where r.authority.id = :authorityId")
-    List<Reservation> findAllByAuthorityId(@Param("authorityId") Long authorityId);
+public interface ReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepositoryCustom {
 
     List<Reservation> findAllByEquipmentGym(EquipmentGym equipmentGym);
 

--- a/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.newfit.reservation.domains.reservation.repository;
+
+import com.newfit.reservation.domains.reservation.domain.Reservation;
+import java.util.List;
+
+public interface ReservationRepositoryCustom {
+    List<Reservation> findAllByAuthorityId(Long authorityId);
+}

--- a/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryImpl.java
@@ -8,7 +8,7 @@ import java.util.List;
 import static com.newfit.reservation.domains.reservation.domain.QReservation.*;
 
 @RequiredArgsConstructor
-public class ReservationRepositoryImpl implements ReservationRepositoryCustom{
+public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.newfit.reservation.domains.reservation.repository;
+
+import com.newfit.reservation.domains.reservation.domain.Reservation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import static com.newfit.reservation.domains.reservation.domain.QReservation.*;
+
+@RequiredArgsConstructor
+public class ReservationRepositoryImpl implements ReservationRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Reservation> findAllByAuthorityId(Long authorityId) {
+        return queryFactory.selectFrom(reservation)
+                .where(reservation.authority.id.eq(authorityId))
+                .fetch();
+    }
+}

--- a/src/test/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.newfit.reservation.domains.reservation.repository;
+
+import com.newfit.reservation.common.config.QuerydslConfig;
+import com.newfit.reservation.domains.reservation.domain.Reservation;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ReservationRepositoryTest {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Test
+    void authorityId로_reservation_모두_조회() {
+        // given
+        Long authorityId = 1L;
+
+        // when
+        List<Reservation> reservations = reservationRepository.findAllByAuthorityId(authorityId);
+
+        // then
+        assertThat(reservations.size()).isEqualTo(3); // db 내부 데이터 수에 따라 변경
+        reservations.forEach(reservation -> {
+            assertThat(reservation.getAuthority().getId()).isEqualTo(authorityId);
+        });
+    }
+}

--- a/src/test/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/newfit/reservation/domains/reservation/repository/ReservationRepositoryTest.java
@@ -29,8 +29,7 @@ class ReservationRepositoryTest {
 
         // then
         assertThat(reservations.size()).isEqualTo(3); // db 내부 데이터 수에 따라 변경
-        reservations.forEach(reservation -> {
-            assertThat(reservation.getAuthority().getId()).isEqualTo(authorityId);
-        });
+        reservations.forEach(reservation ->
+                assertThat(reservation.getAuthority().getId()).isEqualTo(authorityId));
     }
 }


### PR DESCRIPTION
## 개요
- close #274 
## 작업사항
- ReservationRepositoryCustom 추가
- ReservationRepositoryImpl 추가
- test 추가