### PR TITLE
fix: request param의 name을 컨벤션에 맞게 수정 (#296)

### DIFF
--- a/src/main/java/com/newfit/reservation/domains/routine/controller/RoutineApiController.java
+++ b/src/main/java/com/newfit/reservation/domains/routine/controller/RoutineApiController.java
@@ -81,7 +81,7 @@ public class RoutineApiController {
 	public ResponseEntity<Void> updateEquipmentInRoutine(Authentication authentication,
 		@RequestHeader(value = "authority-id") Long authorityId,
 		@Valid @RequestBody UpdateEquipmentRoutineRequest request,
-		@RequestParam("routineId") Long routineId) {
+		@RequestParam("routine_id") Long routineId) {
 		authorityCheckService.validateByAuthorityId(authentication, authorityId);
 		equipmentRoutineService.updateEquipmentRoutinesInRoutine(routineId, request);
 


### PR DESCRIPTION
## 개요
- close #296 
## 작업사항
- request param의 name을 컨벤션에 맞게 수정